### PR TITLE
Fix search results table headings

### DIFF
--- a/app/views/runs/results.haml
+++ b/app/views/runs/results.haml
@@ -7,8 +7,8 @@
     %thead
       %tr
         %th Runner
-        %th Name
         %th Time
+        %th Name
         %th Uploaded
     %tbody
       - @runs.each do |run|


### PR DESCRIPTION
Time was being displayed under the Name heading.

![](https://cdn.mediacru.sh/95Uy6_i13pbq.png)
