### PR TITLE
Fix broken email link on 404 page

### DIFF
--- a/app/views/runs/not_found.slim
+++ b/app/views/runs/not_found.slim
@@ -4,6 +4,7 @@
     small Not Found
 article
   p Those splits either never existed or were deleted.
-  p If you have reason to believe this is a mistake, please
+  p
+    | If you have reason to believe this is a mistake, please
     a<> href="mailto:qhiiyr@gmail.com" email me
-    this URL and why you think so.
+    | this URL and why you think so.


### PR DESCRIPTION
The email link on the 404 page https://splits.io/notALink is broken. This fixes it.