### PR TITLE
Switch forms of binary detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem 'nilify_blanks'
 gem 'babel_bridge'
 gem 'chronic_duration', github: 'glacials/chronic_duration', branch: 'pad_to_option'
 gem 'moving_average'
-gem 'ptools'
+gem 'ruby-filemagic'
 gem 'versionomy'
 gem 'xml-simple'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,6 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    ptools (1.3.2)
     purecss-rails (0.6.0)
       railties (>= 3.2.6, < 5)
     rack (1.6.1)
@@ -348,6 +347,7 @@ GEM
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
+    ruby-filemagic (0.6.3)
     ruby-graphviz (1.2.2)
     ruby-progressbar (1.7.5)
     ruby_parser (3.7.0)
@@ -458,7 +458,6 @@ DEPENDENCIES
   pg
   platform-api
   pry-rails
-  ptools
   purecss-rails
   rails!
   rails-erd
@@ -468,6 +467,7 @@ DEPENDENCIES
   rollbar
   rspec-rails
   rubocop
+  ruby-filemagic
   sass-rails
   simplecov
   slim

--- a/app/models/run_file.rb
+++ b/app/models/run_file.rb
@@ -6,7 +6,13 @@ class RunFile < ActiveRecord::Base
 
   def self.for_file(file)
     if file.respond_to?(:read)
-      if File.binary?(file.path())
+      begin
+        fm = FileMagic.new(FileMagic::MAGIC_MIME)
+        mime_type = fm.file(file.path())
+      ensure
+        fm.close
+      end
+      if mime_type == "application/octet-stream; charset=binary"
         RunFile.for_binary(file.read)
       else
         RunFile.for_text(file.read)


### PR DESCRIPTION
ptools was not flagging all llanfair files as binary, filemagic seems to
be the more accurate version of checking file types.