### PR TITLE
Stop scanning the whole file to check if llanfair

### DIFF
--- a/app/models/run_file.rb
+++ b/app/models/run_file.rb
@@ -7,7 +7,7 @@ class RunFile < ActiveRecord::Base
   def self.for_file(file)
     if file.respond_to?(:read)
       file_text = file.read
-      if file_text.include?("\0")
+      if file_text[8..29] == "org.fenix.llanfair.Run"
         RunFile.for_binary(file_text)
       else
         RunFile.for_text(file_text)


### PR DESCRIPTION
I tested this with every llanfair file I have (around 20) and it worked
fine.  I assume this come from the object serialization of the run
object.