### PR TITLE
Return nil instead of raising error

### DIFF
--- a/app/models/concerns/unparsed_run.rb
+++ b/app/models/concerns/unparsed_run.rb
@@ -23,7 +23,7 @@ module UnparsedRun
           end
 
           if resp.nil?
-            raise "Can't parse run"
+            return nil
           end
 
           return {


### PR DESCRIPTION
Runs will redirect to cant_parse_path instead of 500'ing