### PR TITLE
Update migrations to remove depreciation warning

### DIFF
--- a/db/migrate/20131114225714_devise_create_users.rb
+++ b/db/migrate/20131114225714_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20131114230641_create_runs.rb
+++ b/db/migrate/20131114230641_create_runs.rb
@@ -1,4 +1,4 @@
-class CreateRuns < ActiveRecord::Migration
+class CreateRuns < ActiveRecord::Migration[4.2]
   def change
     create_table :runs do |t|
       t.references :user, index: true

--- a/db/migrate/20131116021616_add_nick_to_runs.rb
+++ b/db/migrate/20131116021616_add_nick_to_runs.rb
@@ -1,4 +1,4 @@
-class AddNickToRuns < ActiveRecord::Migration
+class AddNickToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :nick, :string
   end

--- a/db/migrate/20131116022609_remove_file_from_runs.rb
+++ b/db/migrate/20131116022609_remove_file_from_runs.rb
@@ -1,4 +1,4 @@
-class RemoveFileFromRuns < ActiveRecord::Migration
+class RemoveFileFromRuns < ActiveRecord::Migration[4.2]
   def change
     remove_column :runs, :file, :string
   end

--- a/db/migrate/20131116022646_remove_type_from_runs.rb
+++ b/db/migrate/20131116022646_remove_type_from_runs.rb
@@ -1,4 +1,4 @@
-class RemoveTypeFromRuns < ActiveRecord::Migration
+class RemoveTypeFromRuns < ActiveRecord::Migration[4.2]
   def change
     remove_column :runs, :type, :string
   end

--- a/db/migrate/20131116023518_allow_null_in_run_nicks.rb
+++ b/db/migrate/20131116023518_allow_null_in_run_nicks.rb
@@ -1,4 +1,4 @@
-class AllowNullInRunNicks < ActiveRecord::Migration
+class AllowNullInRunNicks < ActiveRecord::Migration[4.2]
   def change
     change_column :runs, :nick, :string, null: true
   end

--- a/db/migrate/20131116023743_undo_allow_null_in_run_nicks.rb
+++ b/db/migrate/20131116023743_undo_allow_null_in_run_nicks.rb
@@ -1,4 +1,4 @@
-class UndoAllowNullInRunNicks < ActiveRecord::Migration
+class UndoAllowNullInRunNicks < ActiveRecord::Migration[4.2]
   def change
     change_column :runs, :nick, :string
   end

--- a/db/migrate/20131116023821_allow_null_in_run_users.rb
+++ b/db/migrate/20131116023821_allow_null_in_run_users.rb
@@ -1,4 +1,4 @@
-class AllowNullInRunUsers < ActiveRecord::Migration
+class AllowNullInRunUsers < ActiveRecord::Migration[4.2]
   def change
     change_column :runs, :user_id, :integer, null: true
   end

--- a/db/migrate/20131119034023_add_hits_to_runs.rb
+++ b/db/migrate/20131119034023_add_hits_to_runs.rb
@@ -1,4 +1,4 @@
-class AddHitsToRuns < ActiveRecord::Migration
+class AddHitsToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :hits, :integer
   end

--- a/db/migrate/20131119034232_deny_null_in_run_hits.rb
+++ b/db/migrate/20131119034232_deny_null_in_run_hits.rb
@@ -1,4 +1,4 @@
-class DenyNullInRunHits < ActiveRecord::Migration
+class DenyNullInRunHits < ActiveRecord::Migration[4.2]
   def change
     change_column :runs, :hits, :integer, null: false, default: 0
   end

--- a/db/migrate/20140309064339_add_twitch_token_to_users.rb
+++ b/db/migrate/20140309064339_add_twitch_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddTwitchTokenToUsers < ActiveRecord::Migration
+class AddTwitchTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :twitch_token, :string
   end

--- a/db/migrate/20140309164403_add_twitch_id_to_users.rb
+++ b/db/migrate/20140309164403_add_twitch_id_to_users.rb
@@ -1,4 +1,4 @@
-class AddTwitchIdToUsers < ActiveRecord::Migration
+class AddTwitchIdToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :twitch_id, :integer
   end

--- a/db/migrate/20140309165653_add_name_to_users.rb
+++ b/db/migrate/20140309165653_add_name_to_users.rb
@@ -1,4 +1,4 @@
-class AddNameToUsers < ActiveRecord::Migration
+class AddNameToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :name, :string
   end

--- a/db/migrate/20140323203756_add_image_url_to_runs.rb
+++ b/db/migrate/20140323203756_add_image_url_to_runs.rb
@@ -1,4 +1,4 @@
-class AddImageUrlToRuns < ActiveRecord::Migration
+class AddImageUrlToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :image_url, :string
   end

--- a/db/migrate/20140417225035_create_games.rb
+++ b/db/migrate/20140417225035_create_games.rb
@@ -1,4 +1,4 @@
-class CreateGames < ActiveRecord::Migration
+class CreateGames < ActiveRecord::Migration[4.2]
   def change
     create_table :games do |t|
       t.string :name

--- a/db/migrate/20140417230006_create_categories.rb
+++ b/db/migrate/20140417230006_create_categories.rb
@@ -1,4 +1,4 @@
-class CreateCategories < ActiveRecord::Migration
+class CreateCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :categories do |t|
       t.belongs_to :game, index: true

--- a/db/migrate/20140418041340_add_category_to_runs.rb
+++ b/db/migrate/20140418041340_add_category_to_runs.rb
@@ -1,4 +1,4 @@
-class AddCategoryToRuns < ActiveRecord::Migration
+class AddCategoryToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :category_id, :int
   end

--- a/db/migrate/20140418181643_add_time_to_runs.rb
+++ b/db/migrate/20140418181643_add_time_to_runs.rb
@@ -1,4 +1,4 @@
-class AddTimeToRuns < ActiveRecord::Migration
+class AddTimeToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :time, :int
   end

--- a/db/migrate/20140427054848_add_file_to_runs.rb
+++ b/db/migrate/20140427054848_add_file_to_runs.rb
@@ -1,4 +1,4 @@
-class AddFileToRuns < ActiveRecord::Migration
+class AddFileToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :file, :text
   end

--- a/db/migrate/20140705065231_add_name_to_runs.rb
+++ b/db/migrate/20140705065231_add_name_to_runs.rb
@@ -1,4 +1,4 @@
-class AddNameToRuns < ActiveRecord::Migration
+class AddNameToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :name, :string
   end

--- a/db/migrate/20140706071243_convert_run_time_to_decimal.rb
+++ b/db/migrate/20140706071243_convert_run_time_to_decimal.rb
@@ -1,4 +1,4 @@
-class ConvertRunTimeToDecimal < ActiveRecord::Migration
+class ConvertRunTimeToDecimal < ActiveRecord::Migration[4.2]
   def change
     remove_column :runs, :time
     add_column :runs, :time, :decimal

--- a/db/migrate/20140911220946_add_program_to_runs.rb
+++ b/db/migrate/20140911220946_add_program_to_runs.rb
@@ -1,4 +1,4 @@
-class AddProgramToRuns < ActiveRecord::Migration
+class AddProgramToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :program, :string
   end

--- a/db/migrate/20140914061906_add_shortname_to_games.rb
+++ b/db/migrate/20140914061906_add_shortname_to_games.rb
@@ -1,4 +1,4 @@
-class AddShortnameToGames < ActiveRecord::Migration
+class AddShortnameToGames < ActiveRecord::Migration[4.2]
   def change
     add_column :games, :shortname, :string
   end

--- a/db/migrate/20140925230012_add_category_id_index_to_runs.rb
+++ b/db/migrate/20140925230012_add_category_id_index_to_runs.rb
@@ -1,4 +1,4 @@
-class AddCategoryIdIndexToRuns < ActiveRecord::Migration
+class AddCategoryIdIndexToRuns < ActiveRecord::Migration[4.2]
   def change
     add_index :runs, :category_id
   end

--- a/db/migrate/20140925231033_add_shortname_index_to_games.rb
+++ b/db/migrate/20140925231033_add_shortname_index_to_games.rb
@@ -1,4 +1,4 @@
-class AddShortnameIndexToGames < ActiveRecord::Migration
+class AddShortnameIndexToGames < ActiveRecord::Migration[4.2]
   def change
     add_index :games, :shortname
   end

--- a/db/migrate/20140925231311_add_name_index_to_games.rb
+++ b/db/migrate/20140925231311_add_name_index_to_games.rb
@@ -1,4 +1,4 @@
-class AddNameIndexToGames < ActiveRecord::Migration
+class AddNameIndexToGames < ActiveRecord::Migration[4.2]
   def change
     add_index :games, :name
   end

--- a/db/migrate/20140925231319_add_name_index_to_categories.rb
+++ b/db/migrate/20140925231319_add_name_index_to_categories.rb
@@ -1,4 +1,4 @@
-class AddNameIndexToCategories < ActiveRecord::Migration
+class AddNameIndexToCategories < ActiveRecord::Migration[4.2]
   def change
     add_index :categories, :name
   end

--- a/db/migrate/20141028042939_create_delayed_jobs.rb
+++ b/db/migrate/20141028042939_create_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class CreateDelayedJobs < ActiveRecord::Migration
+class CreateDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     create_table :delayed_jobs, :force => true do |table|
       table.integer :priority, :default => 0, :null => false # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20141029211010_allow_null_in_user_emails.rb
+++ b/db/migrate/20141029211010_allow_null_in_user_emails.rb
@@ -1,4 +1,4 @@
-class AllowNullInUserEmails < ActiveRecord::Migration
+class AllowNullInUserEmails < ActiveRecord::Migration[4.2]
   def change
     change_column :users, :email, :string, null: true
   end

--- a/db/migrate/20141102230315_remove_unique_from_user_emails.rb
+++ b/db/migrate/20141102230315_remove_unique_from_user_emails.rb
@@ -1,4 +1,4 @@
-class RemoveUniqueFromUserEmails < ActiveRecord::Migration
+class RemoveUniqueFromUserEmails < ActiveRecord::Migration[4.2]
   def change
     remove_index :users, :email
     add_index :users, :email, unique: false

--- a/db/migrate/20141108070155_add_avatar_to_users.rb
+++ b/db/migrate/20141108070155_add_avatar_to_users.rb
@@ -1,4 +1,4 @@
-class AddAvatarToUsers < ActiveRecord::Migration
+class AddAvatarToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :avatar, :string
   end

--- a/db/migrate/20141109035125_remove_hits_from_runs.rb
+++ b/db/migrate/20141109035125_remove_hits_from_runs.rb
@@ -1,4 +1,4 @@
-class RemoveHitsFromRuns < ActiveRecord::Migration
+class RemoveHitsFromRuns < ActiveRecord::Migration[4.2]
   def change
     remove_column :runs, :hits
   end

--- a/db/migrate/20141109035704_add_visited_to_runs.rb
+++ b/db/migrate/20141109035704_add_visited_to_runs.rb
@@ -1,4 +1,4 @@
-class AddVisitedToRuns < ActiveRecord::Migration
+class AddVisitedToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :visited, :boolean, null: false, default: false
   end

--- a/db/migrate/20141115181021_add_shortname_to_categories.rb
+++ b/db/migrate/20141115181021_add_shortname_to_categories.rb
@@ -1,4 +1,4 @@
-class AddShortnameToCategories < ActiveRecord::Migration
+class AddShortnameToCategories < ActiveRecord::Migration[4.2]
   def change
     add_column :categories, :shortname, :string
   end

--- a/db/migrate/20150106042229_add_srl_id_to_games.rb
+++ b/db/migrate/20150106042229_add_srl_id_to_games.rb
@@ -1,4 +1,4 @@
-class AddSrlIdToGames < ActiveRecord::Migration
+class AddSrlIdToGames < ActiveRecord::Migration[4.2]
   def change
     add_column :games, :srl_id, :integer
   end

--- a/db/migrate/20150106202436_allow_null_in_game_srl_ids.rb
+++ b/db/migrate/20150106202436_allow_null_in_game_srl_ids.rb
@@ -1,4 +1,4 @@
-class AllowNullInGameSrlIds < ActiveRecord::Migration
+class AllowNullInGameSrlIds < ActiveRecord::Migration[4.2]
   def change
     change_column_null :games, :srl_id, true
   end

--- a/db/migrate/20150120052157_add_claim_token_to_runs.rb
+++ b/db/migrate/20150120052157_add_claim_token_to_runs.rb
@@ -1,4 +1,4 @@
-class AddClaimTokenToRuns < ActiveRecord::Migration
+class AddClaimTokenToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :claim_token, :string
   end

--- a/db/migrate/20150124060918_add_sum_of_best_to_runs.rb
+++ b/db/migrate/20150124060918_add_sum_of_best_to_runs.rb
@@ -1,4 +1,4 @@
-class AddSumOfBestToRuns < ActiveRecord::Migration
+class AddSumOfBestToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :sum_of_best, :decimal
   end

--- a/db/migrate/20150124100842_add_archived_to_runs.rb
+++ b/db/migrate/20150124100842_add_archived_to_runs.rb
@@ -1,4 +1,4 @@
-class AddArchivedToRuns < ActiveRecord::Migration
+class AddArchivedToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :archived, :boolean
   end

--- a/db/migrate/20150208082604_create_rivalries.rb
+++ b/db/migrate/20150208082604_create_rivalries.rb
@@ -1,4 +1,4 @@
-class CreateRivalries < ActiveRecord::Migration
+class CreateRivalries < ActiveRecord::Migration[4.2]
   def change
     create_table :rivalries do |t|
       t.belongs_to :category, index: true

--- a/db/migrate/20150208090305_add_video_url_to_runs.rb
+++ b/db/migrate/20150208090305_add_video_url_to_runs.rb
@@ -1,4 +1,4 @@
-class AddVideoUrlToRuns < ActiveRecord::Migration
+class AddVideoUrlToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :video_url, :string
   end

--- a/db/migrate/20150215004913_create_run_files.rb
+++ b/db/migrate/20150215004913_create_run_files.rb
@@ -1,4 +1,4 @@
-class CreateRunFiles < ActiveRecord::Migration
+class CreateRunFiles < ActiveRecord::Migration[4.2]
   def change
     create_table :run_files do |t|
       t.string :digest

--- a/db/migrate/20150215005207_add_run_file_digest_to_runs.rb
+++ b/db/migrate/20150215005207_add_run_file_digest_to_runs.rb
@@ -1,4 +1,4 @@
-class AddRunFileDigestToRuns < ActiveRecord::Migration
+class AddRunFileDigestToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :run_file_digest, :string
   end

--- a/db/migrate/20150330195616_remove_devise_columns_from_users.rb
+++ b/db/migrate/20150330195616_remove_devise_columns_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveDeviseColumnsFromUsers < ActiveRecord::Migration
+class RemoveDeviseColumnsFromUsers < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :encrypted_password
     remove_column :users, :reset_password_token

--- a/db/migrate/20150413004945_add_ignore_history_to_runs.rb
+++ b/db/migrate/20150413004945_add_ignore_history_to_runs.rb
@@ -1,4 +1,4 @@
-class AddIgnoreHistoryToRuns < ActiveRecord::Migration
+class AddIgnoreHistoryToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :ignore_history, :bool
   end

--- a/db/migrate/20150413010844_delete_ignore_history_from_runs.rb
+++ b/db/migrate/20150413010844_delete_ignore_history_from_runs.rb
@@ -1,4 +1,4 @@
-class DeleteIgnoreHistoryFromRuns < ActiveRecord::Migration
+class DeleteIgnoreHistoryFromRuns < ActiveRecord::Migration[4.2]
   def change
     remove_column :runs, :ignore_history
   end

--- a/db/migrate/20150505074746_remove_file_from_runs_again.rb
+++ b/db/migrate/20150505074746_remove_file_from_runs_again.rb
@@ -1,4 +1,4 @@
-class RemoveFileFromRunsAgain < ActiveRecord::Migration
+class RemoveFileFromRunsAgain < ActiveRecord::Migration[4.2]
   def change
     remove_column :runs, :file
   end

--- a/db/migrate/20150506065834_create_splits.rb
+++ b/db/migrate/20150506065834_create_splits.rb
@@ -1,4 +1,4 @@
-class CreateSplits < ActiveRecord::Migration
+class CreateSplits < ActiveRecord::Migration[4.2]
   def change
     create_table :splits do |t|
       t.belongs_to :run, index: true, foreign_key: true

--- a/db/migrate/20150628222744_delete_srl_id_from_games.rb
+++ b/db/migrate/20150628222744_delete_srl_id_from_games.rb
@@ -1,4 +1,4 @@
-class DeleteSrlIdFromGames < ActiveRecord::Migration
+class DeleteSrlIdFromGames < ActiveRecord::Migration[4.2]
   def change
     remove_column :games, :srl_id
   end

--- a/db/migrate/20150704001050_add_srdc_id_to_runs.rb
+++ b/db/migrate/20150704001050_add_srdc_id_to_runs.rb
@@ -1,4 +1,4 @@
-class AddSrdcIdToRuns < ActiveRecord::Migration
+class AddSrdcIdToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :srdc_id, :string
   end

--- a/db/migrate/20150904023532_add_attempts_to_runs.rb
+++ b/db/migrate/20150904023532_add_attempts_to_runs.rb
@@ -1,4 +1,4 @@
-class AddAttemptsToRuns < ActiveRecord::Migration
+class AddAttemptsToRuns < ActiveRecord::Migration[4.2]
   def change
     add_column :runs, :attempts, :integer
   end

--- a/db/migrate/20160326064249_create_game_aliases.rb
+++ b/db/migrate/20160326064249_create_game_aliases.rb
@@ -1,4 +1,4 @@
-class CreateGameAliases < ActiveRecord::Migration
+class CreateGameAliases < ActiveRecord::Migration[4.2]
   def change
     enable_extension :citext
 

--- a/db/migrate/20160327064838_cascade_game_deletes_to_aliases.rb
+++ b/db/migrate/20160327064838_cascade_game_deletes_to_aliases.rb
@@ -1,4 +1,4 @@
-class CascadeGameDeletesToAliases < ActiveRecord::Migration
+class CascadeGameDeletesToAliases < ActiveRecord::Migration[4.2]
   def change
     remove_foreign_key :game_aliases, :games
     add_foreign_key :game_aliases, :games, on_delete: :cascade

--- a/db/migrate/20170401015336_create_authie_sessions.authie.rb
+++ b/db/migrate/20170401015336_create_authie_sessions.authie.rb
@@ -1,5 +1,5 @@
 # This migration comes from authie (originally 20141012174250)
-class CreateAuthieSessions < ActiveRecord::Migration
+class CreateAuthieSessions < ActiveRecord::Migration[4.2]
   def change
     create_table :authie_sessions do |t|
       t.string :token, :browser_id

--- a/db/migrate/20170401015337_add_indexes_to_authie_sessions.authie.rb
+++ b/db/migrate/20170401015337_add_indexes_to_authie_sessions.authie.rb
@@ -1,5 +1,5 @@
 # This migration comes from authie (originally 20141013115205)
-class AddIndexesToAuthieSessions < ActiveRecord::Migration
+class AddIndexesToAuthieSessions < ActiveRecord::Migration[4.2]
   def change
     add_column :authie_sessions, :user_type, :string
     add_index :authie_sessions, :token

--- a/db/migrate/20170401015338_add_parent_id_to_authie_sessions.authie.rb
+++ b/db/migrate/20170401015338_add_parent_id_to_authie_sessions.authie.rb
@@ -1,5 +1,5 @@
 # This migration comes from authie (originally 20150109144120)
-class AddParentIdToAuthieSessions < ActiveRecord::Migration
+class AddParentIdToAuthieSessions < ActiveRecord::Migration[4.2]
   def change
     add_column :authie_sessions, :parent_id, :integer
   end

--- a/db/migrate/20170401015339_add_two_factor_auth_fields_to_authie.authie.rb
+++ b/db/migrate/20170401015339_add_two_factor_auth_fields_to_authie.authie.rb
@@ -1,5 +1,5 @@
 # This migration comes from authie (originally 20150305135400)
-class AddTwoFactorAuthFieldsToAuthie < ActiveRecord::Migration
+class AddTwoFactorAuthFieldsToAuthie < ActiveRecord::Migration[4.2]
   def change
     add_column :authie_sessions, :two_factored_at, :datetime
     add_column :authie_sessions, :two_factored_ip, :string


### PR DESCRIPTION
Adds target rails version identifiers to migrations.