### PR TITLE
Become an OAuth provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'patreon'
 
 # authorization
 gem 'cancancan'
+gem 'doorkeeper'
 
 # db
 gem 'activerecord-import'
@@ -70,6 +71,7 @@ gem 'rest-client'
 gem 'platform-api'
 
 # javascript
+gem 'clipboard-rails'
 gem 'coffee-rails'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
     arel (7.1.4)
     ast (2.3.0)
     authie (2.0.1)
-    autoprefixer-rails (6.4.0.2)
+    autoprefixer-rails (7.1.1.3)
       execjs
     aws-sdk-core (2.5.5)
       jmespath (~> 1.0)
@@ -99,6 +99,7 @@ GEM
     callsite (0.0.11)
     cancancan (1.15.0)
     choice (0.2.0)
+    clipboard-rails (1.7.1)
     coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
@@ -123,6 +124,8 @@ GEM
     docile (1.1.5)
     domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
+    doorkeeper (4.2.6)
+      railties (>= 4.2)
     erubis (2.7.0)
     eventmachine (1.2.0.1)
     excon (0.51.0)
@@ -354,7 +357,7 @@ GEM
     ruby-graphviz (1.2.2)
     ruby-progressbar (1.8.1)
     ruby_dep (1.4.0)
-    sass (3.4.22)
+    sass (3.4.24)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
@@ -431,11 +434,13 @@ DEPENDENCIES
   c3-rails
   cancancan
   chronic_duration!
+  clipboard-rails
   coffee-rails
   d3-rails (~> 3.5.17)
   dalli
   delayed_job_active_record
   descriptive_statistics
+  doorkeeper
   factory_girl_rails
   fakes3
   figaro

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,4 +24,5 @@
 //= require moment
 //= require d3
 //= require c3
+//= require clipboard
 //= require_tree .

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -3,6 +3,7 @@
 @import purecss/grids-responsive
 @import purecss/menus
 @import headings
+@import bootstrap-sprockets
 @import "bootswatch/slate/variables"
 @import bootstrap
 @import "bootswatch/slate/bootswatch"

--- a/app/controllers/api/v3/runs_controller.rb
+++ b/app/controllers/api/v3/runs_controller.rb
@@ -2,6 +2,13 @@ class Api::V3::RunsController < Api::V3::ApplicationController
   before_action :set_run, only: [:show, :destroy, :disown]
   before_action :verify_ownership!, only: [:destroy, :disown]
 
+  before_action only: [:create] do
+    # If an OAuth token is supplied, use it (and fail if it's invalid). Otherwise, upload anonymously.
+    if request.headers['Authorization'].present?
+      doorkeeper_authorize! :upload_run
+    end
+  end
+
   def show
     render json: @run, serializer: Api::V3::Detail::RunSerializer, root: :run
   end

--- a/app/controllers/api/v4/runs_controller.rb
+++ b/app/controllers/api/v4/runs_controller.rb
@@ -4,6 +4,12 @@ class Api::V4::RunsController < Api::V4::ApplicationController
 
   before_action :set_link_headers, if: -> { @run.present? }
 
+  before_action only: [:create] do
+    if current_user.nil? # respect cookie auth
+      doorkeeper_authorize! :upload_run
+    end
+  end
+
   def show
     if params[:historic] == '1'
       @run.parse(fast: false)
@@ -21,7 +27,7 @@ class Api::V4::RunsController < Api::V4::ApplicationController
       rp = {}
     end
 
-    rp = rp.merge(s3_filename: filename)
+    rp = rp.merge(s3_filename: filename, user: current_user)
 
     @run = Run.create(rp)
     if !@run.persisted?

--- a/app/controllers/api/v4/runs_controller.rb
+++ b/app/controllers/api/v4/runs_controller.rb
@@ -5,8 +5,11 @@ class Api::V4::RunsController < Api::V4::ApplicationController
   before_action :set_link_headers, if: -> { @run.present? }
 
   before_action only: [:create] do
-    if current_user.nil? # respect cookie auth
-      doorkeeper_authorize! :upload_run
+    if current_user.nil? # If a cookie is supplied, use it because we're probably on the website.
+      # If an OAuth token is supplied, use it (and fail if it's invalid). Otherwise, upload anonymously.
+      if request.headers['Authorization'].present?
+        doorkeeper_authorize! :upload_run
+      end
     end
   end
 

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -1,0 +1,29 @@
+class ApplicationsController < ApplicationController
+  def new
+  end
+
+  def create
+    @application = Doorkeeper::Application.new(application_params[:doorkeeper_application])
+    @application.owner = current_user if Doorkeeper.configuration.confirm_application_owner?
+    if @application.save
+      redirect_to settings_path, notice: 'Application created! :)'
+    else
+      error_text = @application.errors.full_messages.to_sentence
+      redirect_to new_application_path, alert: ":( Failed to create application: #{error_text}."
+    end
+  end
+
+  def destroy
+    @application = Doorkeeper::Application.find(params[:application])
+    name = @application.name
+    @application.destroy
+
+    redirect_to(settings_path, notice: "#{name} deleted.")
+  end
+
+  private
+
+  def application_params
+    params.permit(doorkeeper_application: [:name, :redirect_uri, :scopes])
+  end
+end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationsController < ApplicationController
+  before_action :set_application, only: [:destroy]
   def new
   end
 
@@ -14,16 +15,22 @@ class ApplicationsController < ApplicationController
   end
 
   def destroy
-    @application = Doorkeeper::Application.find(params[:application])
-    name = @application.name
-    @application.destroy
+    if cannot?(:destroy, @application)
+      render :forbidden, status: 403
+      return
+    end
 
-    redirect_to(settings_path, notice: "#{name} deleted.")
+    @application.destroy
+    redirect_to(settings_path, notice: "#{@application.name} deleted.")
   end
 
   private
 
+  def set_application
+    @application = Doorkeeper::Application.find(params[:application])
+  end
+
   def application_params
-    params.permit(doorkeeper_application: [:name, :redirect_uri, :scopes])
+    params.permit(doorkeeper_application: [:name, :redirect_uri])
   end
 end

--- a/app/controllers/authorized_applications_controller.rb
+++ b/app/controllers/authorized_applications_controller.rb
@@ -1,0 +1,8 @@
+class AuthorizedApplicationsController < Doorkeeper::ApplicationController
+  before_action :authenticate_resource_owner!
+
+  def destroy
+    Doorkeeper::AccessToken.revoke_all_for(params[:application], current_resource_owner)
+    redirect_to settings_path, notice: I18n.t(:notice, scope: [:doorkeeper, :flash, :authorized_applications, :destroy])
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,6 +35,6 @@ class SessionsController < ApplicationController
   private
 
   def redirect_path
-    cookies.delete(:return_to) || root_path
+    request.env['omniauth.origin'] || cookies.delete('return_to') || root_path
   end
 end

--- a/app/helpers/applications_helper.rb
+++ b/app/helpers/applications_helper.rb
@@ -1,0 +1,8 @@
+module ApplicationsHelper
+  def scope_to_sentence(scope)
+    case scope
+    when 'upload_run'
+      "Upload runs on your behalf"
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,6 +8,7 @@ class Ability
 
     can [:update, :create, :destroy], Run.owned, user_id: user.id
     can [:read, :update, :create, :destroy], Rivalry, from_user_id: user.id
+    can [:destroy], Doorkeeper::Application, owner_id: user.id
 
     if user.id == 1
       can [:update, :destroy, :merge], Game

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,10 @@ class User < ApplicationRecord
   has_many :rivalries, foreign_key: :from_user_id, dependent: :destroy
   has_many :incoming_rivalries, class_name: Rivalry, foreign_key: :to_user_id, dependent: :destroy
 
+  has_many :applications, class_name: Doorkeeper::Application, foreign_key: :owner_id
+  has_many :access_grants, class_name: Doorkeeper::AccessGrant, foreign_key: :resource_owner_id
+  has_many :access_tokens, class_name: Doorkeeper::AccessToken, foreign_key: :resource_owner_id
+
   after_destroy do |user|
     user.runs.update_all(user_id: nil)
   end

--- a/app/views/applications/forbidden.slim
+++ b/app/views/applications/forbidden.slim
@@ -1,0 +1,10 @@
+- content_for(:header) do
+  h2
+    | 403
+    small Forbidden
+article
+  p You don't have permission to perform that action.
+  p
+    | If you have reason to believe this is a mistake, please
+    a<> href='mailto:qhiiyr@gmail.com' email me
+    | this URL and why you think so.

--- a/app/views/applications/new.slim
+++ b/app/views/applications/new.slim
@@ -13,10 +13,10 @@
               .input-group.col-md-12
                 p.row
                   .col-md-8
-                    = f.text_field(:name, class: 'form-control', placeholder: 'Application name')
+                    = f.text_field(:name, class: 'form-control', placeholder: 'Application name (what users will see)')
                 p.row
                   .col-md-8
-                    = f.text_field(:redirect_uri, class: 'form-control', placeholder: 'Redirect URI')
+                    = f.text_field(:redirect_uri, class: 'form-control', placeholder: 'Redirect URI (include http:// or https://)')
                   .col-md-4 If you haven't created a page for Splits I/O to redirect users back to yet, put "debug" here.
                 p.row
                   .col-md-8

--- a/app/views/applications/new.slim
+++ b/app/views/applications/new.slim
@@ -1,0 +1,24 @@
+- title "New Application"
+- if current_user.nil?
+  article You need to be signed in to view this page.
+- else
+  article
+      .col-md-12
+        .panel.panel-default
+          .panel-heading Hook into Splits I/O
+          .panel-body
+            p Create a new developer application here. This will let users authorize you to upload runs on their behalf.
+            br
+            = form_for(Doorkeeper::Application.new, url: applications_path) do |f|
+              .input-group.col-md-12
+                p.row
+                  .col-md-8
+                    = f.text_field(:name, class: 'form-control', placeholder: 'Application name')
+                p.row
+                  .col-md-8
+                    = f.text_field(:redirect_uri, class: 'form-control', placeholder: 'Redirect URI')
+                  .col-md-4 If you haven't created a page for Splits I/O to redirect users back to yet, put "debug" here.
+                p.row
+                  .col-md-8
+                    .input-group-btn
+                      = f.submit 'Create', class: 'btn btn-success'

--- a/app/views/doorkeeper/authorizations/error.slim
+++ b/app/views/doorkeeper/authorizations/error.slim
@@ -1,0 +1,15 @@
+- title 'Authorize'
+- if current_user.nil?
+  article You need to be signed in to view this page.
+- else
+  article
+    .row
+      .col-md-6.col-md-offset-3
+        .panel.panel-default
+          .panel-heading
+            b Authorization Request Error
+          .panel-body
+            p
+              big = t('doorkeeper.authorizations.error.title')
+            p = @pre_auth.error_response.body[:error_description]
+

--- a/app/views/doorkeeper/authorizations/new.slim
+++ b/app/views/doorkeeper/authorizations/new.slim
@@ -1,0 +1,48 @@
+- title "settings"
+- if current_user.nil?
+  article You need to be signed in to view this page.
+- else
+  article
+    .row
+      .col-md-6.col-md-offset-3
+        .panel.panel-default
+          .panel-heading
+            b #{@pre_auth.client.name} is requesting partial access to your Splits I/O account
+          .panel-body
+            p
+              span Hey
+              b< #{current_user.twitch_display_name}
+              span ! The application
+            p
+              h4.text-info = @pre_auth.client.name
+            p
+              span is requesting these abilities:
+            p
+              ol
+                li
+                  h5.text-info See who you are on Splits I/O
+                - @pre_auth.scope.split(' ').each do |scope|
+                  li
+                    h5.text-info = scope_to_sentence(scope)
+            p
+              span You can always revoke
+              span.text-info<> #{@pre_auth.client.name}'s
+              span permissions later.
+          .panel-footer
+            .row
+              .col-md-6
+                = form_for oauth_authorization_path, method: :post do |f|
+                  = hidden_field_tag :client_id, @pre_auth.client.uid
+                  = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
+                  = hidden_field_tag :state, @pre_auth.state
+                  = hidden_field_tag :response_type, @pre_auth.response_type
+                  = hidden_field_tag :scope, @pre_auth.scope
+                  = submit_tag t('doorkeeper.authorizations.buttons.authorize'), class: 'btn btn-info btn-lg btn-block'
+              .col-md-6
+                = form_for oauth_authorization_path, method: :delete do |f|
+                  = hidden_field_tag :client_id, @pre_auth.client.uid
+                  = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
+                  = hidden_field_tag :state, @pre_auth.state
+                  = hidden_field_tag :response_type, @pre_auth.response_type
+                  = hidden_field_tag :scope, @pre_auth.scope
+                  = submit_tag t('doorkeeper.authorizations.buttons.deny'), class: 'btn btn-default btn-lg btn-block'

--- a/app/views/doorkeeper/authorizations/new.slim
+++ b/app/views/doorkeeper/authorizations/new.slim
@@ -1,4 +1,4 @@
-- title "settings"
+- title "Authorize"
 - if current_user.nil?
   article You need to be signed in to view this page.
 - else

--- a/app/views/doorkeeper/authorizations/show.slim
+++ b/app/views/doorkeeper/authorizations/show.slim
@@ -1,0 +1,31 @@
+- title "settings"
+article
+  .row
+    .col-md-6.col-md-offset-3
+      .panel.panel-default
+        .panel-heading Authorization Code Created
+        .panel-body
+          p It works! Here's your authorization code.
+          p
+            .input-group
+              input.form-control id="code" type='text' value=params[:code] readonly=1
+              .input-group-btn
+                .btn.btn-default.clipboard-btn data-clipboard-target="#code"
+                  .glyphicon.glyphicon-copy#copy
+                  .glyphicon.glyphicon-ok#copied style='display: none;'
+          coffee:
+            clipboard = new Clipboard('.clipboard-btn')
+            clipboard.on('success', (e) ->
+              e.trigger.children[0].style.display = 'none'
+              e.trigger.children[1].style.display = 'inline-block'
+              setTimeout(->
+                e.trigger.children[0].style.display = 'inline-block'
+                e.trigger.children[1].style.display = 'none'
+              , 4000)
+            )
+          p
+            span> In a production environment, your users won't see this page and will instead be sent to your
+            code redirect_uri
+            span<> with a
+            code code
+            span< URL param containing this value.

--- a/app/views/settings/index.slim
+++ b/app/views/settings/index.slim
@@ -42,7 +42,7 @@
           .panel-heading Authorized Applications
           .panel-body
             - if current_user.access_tokens.count == 0
-              i You have not authorized any applications to use your account.
+              i There are no applications authorized to use your account.
             - else
               p These applications have partial access to your account.
               table.table.table-striped.table-hover
@@ -53,19 +53,20 @@
                     th Authorized
                     th
                 tbody
-                  - current_user.access_tokens.each do |token|
+                  - Doorkeeper::Application.authorized_for(current_user).each do |application|
+                    - auth = Doorkeeper::AccessToken.find_by(resource_owner_id: current_user, application: application)
                     tr
                       td
-                        big = token.application.name
+                        big = application.name
                       td
                         ul
-                          - token.scopes.all.each do |scope|
+                          - auth.scopes.all.each do |scope|
                             li = scope_to_sentence(scope)
                       td
-                        div title=token.created_at #{time_ago_in_words(token.created_at)} ago
+                        div title=auth.created_at #{time_ago_in_words(auth.created_at)} ago
                       td
-                        = button_to oauth_authorization_path(token), class: 'btn btn-default', method: :delete, data: {\
-                          confirm: "Really revoke permissions from #{token.application.name}?"\
+                        = button_to authorization_path(application.id), class: 'btn btn-default', method: :delete, data: {\
+                          confirm: "Really revoke permissions from #{application.name}?"\
                         }
                           .glyphicon.glyphicon-remove
       .col-md-12

--- a/app/views/settings/index.slim
+++ b/app/views/settings/index.slim
@@ -1,62 +1,167 @@
 - title "settings"
 - content_for(:header)
-	h2 Settings
+  h2 Settings
 - if current_user.nil?
-	article You need to be signed in to view this page.
+  article You need to be signed in to view this page.
 - else
-	article
-		.row
-			.col-md-6
-				.panel.panel-default
-					.panel-body style='background: rgba(100, 65, 164, 1); color: #fff;'
-						span> ✓ Linked with Twitch as
-						b> = current_user
-						.pull-right
-							i.btn.btn-default.disabled Not unlinkable
-					.panel-footer
-						.row
-							.col-md-12
-								a.btn.btn-default href=current_user.uri target='_blank' Visit my Twitch channel
-			.col-md-6
-				.panel.panel-default
-					.panel-body style='background: rgba(230, 70, 26, 1.00); color: #fff;'
-						- patreon = current_user.patreon_info
-						- if patreon.nil?
-							span> ✗ Not linked with Patreon
-							.pull-right
-								a.btn.btn-default href='/auth/patreon' Link
-						- else
-							span> ✓ Linked with Patreon as
-							b> = patreon['patreon_full_name'] || '???'
-							.pull-right
-								a.btn.btn-default href='/auth/patreon/unlink' Unlink
-					.panel-footer
-						.row
-							.col-md-6
-								a.btn.btn-default> href='https://www.patreon.com/glacials' target='_blank' Visit the Splits I/O Patreon
-							- if current_user.gold_patron?
-								.col-md-6
-									a.btn.btn-success href=tools_path View my permalink redirectors
-	article
-		.row
-			.col-md-12
-				.panel.panel-danger
-					.panel-heading Delete My Account
-					.panel-body
-						p If you like, you can permanently delete your account on Splits I/O. You can recreate it later by signing in with
-							Twitch again, but it will be a fresh account with no runs.
-						p You can choose to cascade this deletion to all your runs, or to disown them instead. Disowned runs do not belong to
-							any user and will not be claimable, even if you recreate your account. Your name will not appear on them.
-						p This is a hard delete. No one can restore your account if you change your mind.
-						.col-md-6
-							center
-								= button_to user_path(current_user), method: :delete, data: {confirm: "Really delete your account (#{current_user})? Your existing runs will be permanently deleted."}, params: {destroy_runs: '1'}, class: 'button btn btn-danger'
-									div
-										big Delete my account
-									small Deleting #{current_user.runs.count} runs (#{current_user.pbs.count} PBs) across #{current_user.games.count} games with it
-						.col-md-6
-							center
-								= button_to user_path(current_user), method: :delete, data: {confirm: "Really delete your account (#{current_user})? Your existing runs will be disowned."}, class: 'button btn btn-danger'
-									div
-										big Delete my account
-									small Keeping all runs, but anonymizing them permanently
+  article
+    .row
+      .col-md-6
+        .panel.panel-default
+          .panel-body style='background: rgba(100, 65, 164, 1); color: #fff;'
+            span> ✓ Linked with Twitch as
+            b> = current_user
+            .pull-right
+              i.btn.btn-default.disabled Not unlinkable
+          .panel-footer
+            .row
+              .col-md-12
+                a.btn.btn-default href=current_user.uri target='_blank' Visit my Twitch channel
+      .col-md-6
+        .panel.panel-default
+          .panel-body style='background: rgba(230, 70, 26, 1.00); color: #fff;'
+            - patreon = current_user.patreon_info
+            - if patreon.nil?
+              span> ✗ Not linked with Patreon
+              .pull-right
+                a.btn.btn-default href='/auth/patreon' Link
+            - else
+              span> ✓ Linked with Patreon as
+              b> = patreon['patreon_full_name'] || '???'
+              .pull-right
+                a.btn.btn-default href='/auth/patreon/unlink' Unlink
+          .panel-footer
+            .row
+              .col-md-6
+                a.btn.btn-default> href='https://www.patreon.com/glacials' target='_blank' Visit the Splits I/O Patreon
+              - if current_user.gold_patron?
+                .col-md-6
+                  a.btn.btn-success href=tools_path View my permalink redirectors
+      .col-md-12
+        .panel.panel-default
+          .panel-heading Authorized Applications
+          .panel-body
+            - if current_user.access_tokens.count == 0
+              i You have not authorized any applications to use your account.
+            - else
+              p These applications have partial access to your account.
+              table.table.table-striped.table-hover
+                thead
+                  tr
+                    th Name
+                    th Permissions granted
+                    th Authorized
+                    th
+                tbody
+                  - current_user.access_tokens.each do |token|
+                    tr
+                      td
+                        big = token.application.name
+                      td
+                        ul
+                          - token.scopes.all.each do |scope|
+                            li = scope_to_sentence(scope)
+                      td
+                        div title=token.created_at #{time_ago_in_words(token.created_at)} ago
+                      td
+                        = button_to oauth_authorization_path(token), class: 'btn btn-default', method: :delete, data: {\
+                          confirm: "Really revoke permissions from #{token.application.name}?"\
+                        }
+                          .glyphicon.glyphicon-remove
+      .col-md-12
+        .panel.panel-default
+          .panel-heading My Developer Applications
+          .panel-body
+            .btn-group
+              a.btn.btn-default href='/settings/applications/new'
+                .glyphicon.glyphicon-plus>
+                | Create Application
+              a.btn.btn-primary target='_blank' href='https://github.com/glacials/splits-io/blob/master/docs/api.md'
+                .glyphicon.glyphicon-file>
+                | View Documentation
+            - if current_user.applications.empty?
+              article
+                p If you're a developer of another application like a timer, you can use this section to let your users
+                  authorize you to upload runs on their behalf.
+                p If you're not a developer, you can ignore this section.
+            - else
+              p
+                table.table.table-striped.table-hover
+                  thead
+                    tr
+                      th Name
+                      th Active Tokens
+                      th Redirect URI
+                      th Client ID
+                      th
+                        span> Client Secret &mdash;
+                        small.text-warning
+                          .glyphicon.glyphicon-time
+                          span< Hides forever after 24 hours
+                      th
+                  tbody
+                    - current_user.applications.each do |application|
+                      tr
+                        td
+                          big = application.name
+                        td = application.access_tokens.count
+                        td
+                          code = application.redirect_uri
+                        td
+                          .input-group
+                            input.form-control id="client-id-#{application.uid}" type='text' value=application.uid readonly=1
+                            .input-group-btn
+                              .btn.btn-default.clipboard-btn data-clipboard-target="#client-id-#{application.uid}"
+                                .glyphicon.glyphicon-copy#copy
+                                .glyphicon.glyphicon-ok#copied style='display: none;'
+                        td
+                          - if (Time.now - 24.hours) > application.created_at
+                            i Hidden forever
+                          - else
+                            .input-group
+                              input.form-control id="client-secret-#{application.uid}" type='text' value=application.secret readonly=1
+                              .input-group-btn
+                                .btn.btn-default.clipboard-btn data-clipboard-target="#client-secret-#{application.uid}"
+                                  .glyphicon.glyphicon-copy#copy
+                                  .glyphicon.glyphicon-ok#copied style='display: none;'
+                        coffee:
+                          clipboard = new Clipboard('.clipboard-btn')
+                          clipboard.on('success', (e) ->
+                            e.trigger.children[0].style.display = 'none'
+                            e.trigger.children[1].style.display = 'inline-block'
+                            setTimeout(->
+                              e.trigger.children[0].style.display = 'inline-block'
+                              e.trigger.children[1].style.display = 'none'
+                            , 4000)
+                          )
+                        td
+                          small = button_to application_path(application), class: 'btn btn-default', method: :delete, \
+                            data: { \
+                              confirm: "Really delete #{application.name}? This will also revoke all \
+                                        #{application.access_tokens.count} authorizations and invalidate the associated \
+                                        tokens." \
+                            }
+                            .glyphicon.glyphicon-remove
+  article
+    .row
+      .col-md-12
+        .panel.panel-danger
+          .panel-heading Delete My Account
+          .panel-body
+            p If you like, you can permanently delete your account on Splits I/O. You can recreate it later by signing in with
+              Twitch again, but it will be a fresh account with no runs.
+            p You can choose to cascade this deletion to all your runs, or to disown them instead. Disowned runs do not belong to
+              any user and will not be claimable, even if you recreate your account. Your name will not appear on them.
+            p This is a hard delete. No one can restore your account if you change your mind.
+            .col-md-6
+              center
+                = button_to user_path(current_user), method: :delete, data: {confirm: "Really delete your account (#{current_user})? Your existing runs will be permanently deleted."}, params: {destroy_runs: '1'}, class: 'button btn btn-danger'
+                  div
+                    big Delete my account
+                  small Deleting #{current_user.runs.count} runs (#{current_user.pbs.count} PBs) across #{current_user.games.count} games with it
+            .col-md-6
+              center
+                = button_to user_path(current_user), method: :delete, data: {confirm: "Really delete your account (#{current_user})? Your existing runs will be disowned."}, class: 'button btn btn-danger'
+                  div
+                    big Delete my account
+                  small Keeping all runs, but anonymizing them permanently

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,10 @@ module SplitsIO
     end
 
     ActiveSupport.halt_callback_chains_on_return_false = false
+
+    config.to_prepare do
+      Doorkeeper::AuthorizationsController.layout 'application'
+    end
   end
 end
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,76 @@
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use (needs plugins)
+  orm :active_record
+
+  # This block will be called to check whether the resource owner is authenticated or not.
+  resource_owner_authenticator do
+   current_user || redirect_to(root_path)
+  end
+
+  authorization_code_expires_in 10.minutes
+  access_token_expires_in 2.hours
+
+  use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter confirmation: true (default false) if you want to enforce ownership of
+  # a registered application
+  enable_application_owner confirmation: true
+
+  # Define access token scopes for your provider
+  # For more information go to
+  # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
+  # default_scopes  :public
+  optional_scopes :upload_run
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out the wiki for more information on customization
+  client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out the wiki for more information on customization
+  access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Change the native redirect uri for client apps
+  # When clients register with the following redirect uri, they won't be redirected to any server and the authorization code will be displayed within the provider
+  # The value can be any string. Use nil to disable this feature. When disabled, clients must provide a valid URL.
+  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
+  native_redirect_uri 'debug'
+
+  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+  # by default in non-development environments). OAuth2 delegates security in
+  # communication to the HTTPS protocol so it is wise to keep this enabled.
+  force_ssl_in_redirect_uri !Rails.env.development?
+
+  # Specify what grant flows are enabled in array of Strings. The valid
+  # strings and the flows they enable are:
+  #
+  # "authorization_code" => Authorization Code Grant Flow
+  # "implicit"           => Implicit Grant Flow
+  # "password"           => Resource Owner Password Credentials Grant Flow
+  # "client_credentials" => Client Credentials Grant Flow
+  #
+  # If not specified, Doorkeeper enables authorization_code and
+  # client_credentials.
+  #
+  # implicit and password grant flows have risks that you should understand
+  # before enabling:
+  #   http://tools.ietf.org/html/rfc6819#section-4.4.2
+  #   http://tools.ietf.org/html/rfc6819#section-4.4.3
+  #
+  grant_flows %w(authorization_code client_credentials implicit)
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with a trusted application.
+  # skip_authorization do |resource_owner, client|
+  #   client.superapp? or resource_owner.admin?
+  # end
+
+  # WWW-Authenticate Realm (default "Doorkeeper").
+  # realm "Doorkeeper"
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -4,7 +4,11 @@ Doorkeeper.configure do
 
   # This block will be called to check whether the resource owner is authenticated or not.
   resource_owner_authenticator do
-   current_user || redirect_to(root_path)
+    if current_user.nil?
+      cookies['return_to'] = request.fullpath
+      redirect_to('/auth/twitch')
+    end
+    current_user
   end
 
   authorization_code_expires_in 10.minutes

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,124 @@
+en:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: 'Name'
+        redirect_uri: 'Redirect URI'
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+              secured_uri: 'must be an HTTPS/SSL URI.'
+
+  doorkeeper:
+    applications:
+      confirmations:
+        destroy: 'Are you sure?'
+      buttons:
+        edit: 'Edit'
+        destroy: 'Destroy'
+        submit: 'Submit'
+        cancel: 'Cancel'
+        authorize: 'Authorize'
+      form:
+        error: 'Whoops! Check your form for possible errors'
+      help:
+        redirect_uri: 'Use one line per URI'
+        native_redirect_uri: 'Use %{native_redirect_uri} for local tests'
+        scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
+      edit:
+        title: 'Edit application'
+      index:
+        title: 'Your applications'
+        new: 'New Application'
+        name: 'Name'
+        callback_url: 'Callback URL'
+      new:
+        title: 'New Application'
+      show:
+        title: 'Application: %{name}'
+        application_id: 'Application Id'
+        secret: 'Secret'
+        scopes: 'Scopes'
+        callback_urls: 'Callback urls'
+        actions: 'Actions'
+
+    authorizations:
+      buttons:
+        authorize: 'Authorize'
+        deny: 'Deny'
+      error:
+        title: 'An error has occurred'
+      new:
+        title: 'Authorization required'
+        prompt: 'Authorize %{client_name} to use your account?'
+        able_to: 'This application will be able to'
+      show:
+        title: 'Authorization code'
+
+    authorized_applications:
+      confirmations:
+        revoke: 'Are you sure?'
+      buttons:
+        revoke: 'Revoke'
+      index:
+        title: 'Your authorized applications'
+        application: 'Application'
+        created_at: 'Created At'
+        date_format: '%Y-%m-%d %H:%M:%S'
+
+    errors:
+      messages:
+        # Common error messages
+        invalid_request: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+        invalid_redirect_uri: 'The redirect uri included is not valid.'
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        # Configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        # Password Access token errors
+        invalid_resource_owner: 'The provided resource owner credentials are not valid, or resource owner cannot be found'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'
+
+    layouts:
+      admin:
+        nav:
+          oauth2_provider: 'OAuth2 Provider'
+          applications: 'Applications'
+          home: 'Home'
+      application:
+        title: 'OAuth authorization required'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 SplitsIO::Application.routes.draw do
+  use_doorkeeper do
+    skip_controllers :applications, :authorized_applications
+  end
+
   root 'runs#index'
 
   get '/faq',       to: 'pages#faq',            as: :faq
@@ -63,7 +67,11 @@ SplitsIO::Application.routes.draw do
     as: :game_category_sum_of_bests
 
   resources :tools, only: [:index]
-  resources :settings, only: [:index]
+
+  get    '/settings',                           to: 'settings#index',       as: :settings
+  get    '/settings/applications/new',          to: 'applications#new',     as: :new_application
+  post   '/settings/applications',              to: 'applications#create',  as: :applications
+  delete '/settings/applications/:application', to: 'applications#destroy', as: :application
 
   get    '/:run/edit',                      to: 'runs#edit',        as: :edit_run
   get    '/:run/stats',                     to: 'runs/stats#index', as: :run_stats

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,9 +69,11 @@ SplitsIO::Application.routes.draw do
   resources :tools, only: [:index]
 
   get    '/settings',                           to: 'settings#index',       as: :settings
-  get    '/settings/applications/new',          to: 'applications#new',     as: :new_application
-  post   '/settings/applications',              to: 'applications#create',  as: :applications
-  delete '/settings/applications/:application', to: 'applications#destroy', as: :application
+
+  get    '/settings/applications/new',            to: 'applications#new',                as: :new_application
+  post   '/settings/applications',                to: 'applications#create',             as: :applications
+  delete '/settings/applications/:application',   to: 'applications#destroy',            as: :application
+  delete '/settings/authorizations/:application', to: 'authorized_applications#destroy', as: :authorization
 
   get    '/:run/edit',                      to: 'runs#edit',        as: :edit_run
   get    '/:run/stats',                     to: 'runs/stats#index', as: :run_stats

--- a/db/migrate/20170616045119_create_doorkeeper_tables.rb
+++ b/db/migrate/20170616045119_create_doorkeeper_tables.rb
@@ -1,0 +1,68 @@
+class CreateDoorkeeperTables < ActiveRecord::Migration
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,         null: false
+      t.string  :uid,          null: false
+      t.string  :secret,       null: false
+      t.text    :redirect_uri, null: false
+      t.string  :scopes,       null: false, default: ''
+      t.timestamps             null: false
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants do |t|
+      t.integer  :resource_owner_id, null: false
+      t.references :application,     null: false
+      t.string   :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+      t.string   :scopes
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+    add_foreign_key(
+      :oauth_access_grants,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    create_table :oauth_access_tokens do |t|
+      t.integer  :resource_owner_id
+      t.references :application
+
+      # If you use a custom token generator you may need to change this column
+      # from string to text, so that it accepts tokens larger than 255
+      # characters. More info on custom token generators in:
+      # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
+      #
+      # t.text     :token,             null: false
+      t.string   :token,                  null: false
+
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.datetime :revoked_at
+      t.datetime :created_at,             null: false
+      t.string   :scopes
+
+      # If there is a previous_refresh_token column,
+      # refresh tokens will be revoked after a related access token is used.
+      # If there is no previous_refresh_token column,
+      # previous tokens are revoked as soon as a new access token is created.
+      # Comment out this line if you'd rather have refresh tokens
+      # instantly revoked.
+      t.string   :previous_refresh_token, null: false, default: ""
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+    add_index :oauth_access_tokens, :resource_owner_id
+    add_index :oauth_access_tokens, :refresh_token, unique: true
+    add_foreign_key(
+      :oauth_access_tokens,
+      :oauth_applications,
+      column: :application_id
+    )
+  end
+end

--- a/db/migrate/20170616045820_add_owner_to_application.rb
+++ b/db/migrate/20170616045820_add_owner_to_application.rb
@@ -1,0 +1,7 @@
+class AddOwnerToApplication < ActiveRecord::Migration
+  def change
+    add_column :oauth_applications, :owner_id, :integer, null: true
+    add_column :oauth_applications, :owner_type, :string, null: true
+    add_index :oauth_applications, [:owner_id, :owner_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170612022253) do
+ActiveRecord::Schema.define(version: 20170616045820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,47 @@ ActiveRecord::Schema.define(version: 20170612022253) do
     t.string   "shortname"
     t.index ["name"], name: "index_games_on_name", using: :btree
     t.index ["shortname"], name: "index_games_on_shortname", using: :btree
+  end
+
+  create_table "oauth_access_grants", force: :cascade do |t|
+    t.integer  "resource_owner_id", null: false
+    t.integer  "application_id",    null: false
+    t.string   "token",             null: false
+    t.integer  "expires_in",        null: false
+    t.text     "redirect_uri",      null: false
+    t.datetime "created_at",        null: false
+    t.datetime "revoked_at"
+    t.string   "scopes"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
+  end
+
+  create_table "oauth_access_tokens", force: :cascade do |t|
+    t.integer  "resource_owner_id"
+    t.integer  "application_id"
+    t.string   "token",                               null: false
+    t.string   "refresh_token"
+    t.integer  "expires_in"
+    t.datetime "revoked_at"
+    t.datetime "created_at",                          null: false
+    t.string   "scopes"
+    t.string   "previous_refresh_token", default: "", null: false
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
+  end
+
+  create_table "oauth_applications", force: :cascade do |t|
+    t.string   "name",                      null: false
+    t.string   "uid",                       null: false
+    t.string   "secret",                    null: false
+    t.text     "redirect_uri",              null: false
+    t.string   "scopes",       default: "", null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.integer  "owner_id"
+    t.string   "owner_type"
+    t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", using: :btree
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
   end
 
   create_table "rivalries", force: :cascade do |t|
@@ -178,6 +219,8 @@ ActiveRecord::Schema.define(version: 20170612022253) do
   end
 
   add_foreign_key "game_aliases", "games", on_delete: :cascade
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "segment_histories", "segments", on_delete: :cascade
   add_foreign_key "segments", "runs", on_delete: :cascade
   add_foreign_key "splits", "runs"

--- a/docs/api.md
+++ b/docs/api.md
@@ -368,9 +368,9 @@ on their behalf. If they accept, you will receive an OAuth token which you can i
 order to create the run as that user.
 
 The following instructions go into naive-case details about implementing this OAuth support in your application. If you
-want to learn more about OAuth or need general OAuth troubleshooting help, you can research OAuth2 online. Especially if
-your application is a website, it's likely that the language you're using has well-established libraries that handle
-much of the below OAuth flow for you.
+want to learn more about OAuth or need general OAuth troubleshooting help, you can [research OAuth2
+online][oauth2-simplified]. Especially if your application is a website, it's likely that the language you're using has
+well-established libraries that handle much of the below OAuth flow for you.
 
 In all cases, you'll need to first go to your Splits I/O account's [settings page][1] and create an application, then
 refer to the relevant section below.
@@ -379,6 +379,8 @@ refer to the relevant section below.
 ```http
 GET https://splits.io/oauth/token/info?access_token=YOUR_TOKEN
 ```
+
+[oauth2-simplified]: https://aaronparecki.com/oauth-2-simplified/
 
 #### Example 1: My application is a local program that runs on the user's computer
 If your application runs locally as a program on a user's computer, you should use OAuth's **authorization code grant

--- a/docs/api.md
+++ b/docs/api.md
@@ -432,7 +432,7 @@ for an OAuth token using a secure API request.
     Success! `access_token` is your OAuth token for the user. Use it in your API requests to act on behalf of the user
     by including this header in your requests:
     ```http
-    Bearer: OAuth YOUR_ACCESS_TOKEN
+    Authorization: Bearer YOUR_ACCESS_TOKEN
     ```
     The access token expires after the duration specified in `expires_in` (measured in seconds). After it expires, you
     can retrieve a new one with no user intervention using the returned `refresh_token`:
@@ -474,7 +474,7 @@ should use OAuth's **implicit grant flow**.
     Success! `access_token` is your OAuth token for the user. Use it in your API requests to act on behalf of the user
     by including this header in your requests:
     ```http
-    Bearer: OAuth YOUR_ACCESS_TOKEN
+    Authorization: Bearer YOUR_ACCESS_TOKEN
     ```
     The access token expires after the duration specified in `expires_in` (measured in seconds). After it expires, you
     can retrieve a new one with no user intervention using redirection upon accessing your app, or a hidden iframe to
@@ -534,7 +534,7 @@ using a secure API request.
     Success! `access_token` is your OAuth token for the user. Use it in your API requests to act on behalf of the user
     by including this header in your requests:
     ```http
-    Bearer: OAuth YOUR_ACCESS_TOKEN
+    Authorization: Bearer YOUR_ACCESS_TOKEN
     ```
     The access token expires after the duration specified in `expires_in` (measured in seconds). After it expires, you
     can retrieve a new one with no user intervention using the returned `refresh_token`:

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,10 +8,10 @@ These docs are for the v3 API.
 ### [Run Endpoints][run-endpoints]
 ### [Uploading Runs on Behalf of a User][authorization]
 
-[game-endpoints]: #game-endpoints
-[user-endpoints]: #user-endpoints
-[run-endpoints]: #run-endpoints
-[authorization]: #uploading-runs-on-behalf-of-a-user
+[game-endpoints]: #game-endpoints-1
+[user-endpoints]: #user-endpoints-1
+[run-endpoints]: #run-endpoints-1
+[authorization]: #uploading-runs-on-behalf-of-a-user-1
 
 ## Pagination
 Routes that return array resources are paginated to 20 items per page. To get a specific page of results, add `?page=N`

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,18 @@
 # splits i/o API
 These docs are for the v3 API.
 
+## Jump to section
+
+### [Game Endpoints][game-endpoints]
+### [User Endpoints][user-endpoints]
+### [Run Endpoints][run-endpoints]
+### [Uploading Runs on Behalf of a User][authorization]
+
+[game-endpoints]: #game-endpoints
+[user-endpoints]: #user-endpoints
+[run-endpoints]: #run-endpoints
+[authorization]: #uploading-runs-on-behalf-of-a-user
+
 ## Pagination
 Routes that return array resources are paginated to 20 items per page. To get a specific page of results, add `?page=N`
 to your API hit. The default page is page 1. You'll find pagination info in the HTTP headers of every paginated response
@@ -9,7 +21,7 @@ under the `Link`, `Total`, and `Per-Page` fields.
 ## Overview of routes
 Base URL is **https://splits.io/api/v3**.
 
-### Based on game
+### Game Endpoints Overview
 Game ids are SRL shortnames (e.g. `sms`, `oot`, etc.) or Splits I/O base 10 `id`s (which you can discover in other
 routes).
 
@@ -21,7 +33,7 @@ GET /games/:game_id/categories/:id
 GET /games/:game_id/categories/:category_id/runs
 ```
 
-### Based on user
+### User Endpoints Overview
 User ids are Twitch usernames or Splits I/O base 10 `id`s.
 
 ```http
@@ -33,7 +45,7 @@ GET /users/:user_id/games/:game_id/categories/:category_id/pb
 GET /users/:user_id/games/:game_id/categories/:category_id/prediction
 ```
 
-### Based on run
+### Run Endpoints Overview
 Run ids are Splits I/O base 36 ids. These are the strings you see in user-friendly run URLs like `splits.io/36s`.
 
 ```http
@@ -44,7 +56,7 @@ POST /runs
 
 ## Route details
 
-### Based on game
+### Game Endpoints
 Game ids are SRL shortnames (e.g. `sms`, `oot`, etc.) or Splits I/O base 10 `id`s (which you can discover in other
 routes).
 
@@ -156,7 +168,7 @@ curl https://splits.io/api/v3/games/sms/categories/70/runs
 }
 ```
 
-### Based on user
+### User Endpoints
 User ids are Twitch usernames (which we call `name`) or Splits I/O base 10 `id`s.
 
 #### `GET /users/:id`
@@ -249,7 +261,7 @@ Returns a prediction of this user's next run of this category. Predictions use p
 all recorded run history of the user for this category. The response for this endpoint looks like a response to a
 normal "get run" endpoint, but has a `null` id.
 
-### Based on run
+### Run Endpoints
 Run ids are Splits I/O base 36 ids. These are the strings you see in user-friendly run URLs like `splits.io/36s`.
 
 #### `GET /runs/:id`
@@ -334,3 +346,212 @@ curl -iX POST --form file=@/path/to/splits_file.lss https://splits.io/api/v3/run
   }
 }
 ```
+
+## Uploading Runs on Behalf of a User
+If you want to upload runs for a user (e.g. from within a timer), you have two options.
+
+### Simple option
+Upload the run without auth and direct the user to the URL in the response body's `uris.claim_uri`. If they are logged
+in when they visit it, their account will automatically claim the run.
+
+This is the easier method to implement, but has some flaws:
+
+- The user must open the run in their web browser. If you prefer to upload runs in the background, this method isn't for
+  you.
+- If there are network or browser issues when the user's browser tries to load the run, it won't be claimed.
+- If the user isn't logged in when their browser opens, the run will remain unclaimed. Neither your application nor the
+  user will receive any indication of this.
+
+### Advanced option
+The advanced option is a standard OAuth2 flow. You can request permission from the user to upload runs to their account
+on their behalf. If they accept, you will receive an OAuth token which you can include in your run upload requests in
+order to create the run as that user.
+
+The following instructions go into naive-case details about implementing this OAuth support in your application. If you
+want to learn more about OAuth or need general OAuth troubleshooting help, you can research OAuth2 online. Especially if
+your application is a website, it's likely that the language you're using has well-established libraries that handle
+much of the below OAuth flow for you.
+
+In all cases, you'll need to first go to your Splits I/O account's [settings page][1] and create an application. Add the
+`upload_run` scope to the list of needed scopes, then refer to the relevant section below.
+
+*Note: Once you have an OAuth token, you can use a request like this to retrieve information about it:*
+```http
+GET https://splits.io/oauth/token/info?access_token=YOUR_TOKEN
+```
+
+#### Example 1: My application is a local program that runs on the user's computer
+If your application runs locally as a program on a user's computer, you should use OAuth's **authorization code grant
+flow**. This means your application will open the Splits I/O authorization page in the user's default browser, and if
+the user accepts the authorization, Splits I/O will give your application a `code` which you should immediately exchange
+for an OAuth token using a secure API request.
+
+1. Configure your program to run a small web server on a port of your choosing, and listen for `GET` requests to a path
+    of your choosing. In this example, let's say you're listening on port 8000 for requests to `/auth/splitsio`.
+2. On your Splits I/O [settings page][1], set your `redirect_uri` to something like
+    ```http
+    http://localhost:8000/auth/splitsio
+    ```
+    *Hint: Set this to "debug" for now if you don't yet have a page to redirect yourself to.*
+
+    Set your requested scopes to `upload_run`.
+3. When a user wants to grant authorization to your application for their Splits I/O account, send them to a URL like
+    this:
+    ```http
+    https://splits.io/oauth/authorize?response_type=code&scope=upload_run&redirect_uri=http://localhost:8000/auth/splitsio&client_id=YOUR_CLIENT_ID
+    ```
+    If the user authorizes your application, they will be redirected to a URL like
+    ```http
+    http://localhost:8000/auth/splitsio?code=YOUR_CODE
+    ```
+    which the web server you set up in step 1 should respond to. Give the user a nice-looking HTML page saying to switch
+    back to the application and strip the `code` URL parameter for the next step.
+4. Use your `code` to make this request:
+    ```http
+    POST https://splits.io/oauth/token
+    ```
+    with this body:
+    ```http
+    grant_type=authorization_code
+    client_id=YOUR_CLIENT_ID
+    client_secret=YOUR_CLIENT_SECRET
+    code=YOUR_CODE
+    redirect_uri=http://localhost:8000/auth/splitsio
+    ```
+    which will respond with something like this:
+    ```json
+    {
+      "access_token": "0e82e0ac69fed3c6e5044682a9eb94ccded5ace70e84838104a131cb50595cd2",
+      "token_type": "bearer",
+      "expires_in": 7200,
+      "refresh_token": "0e23b095e0d0104ff0642cde71b61d236f3b3865734a0e734714ecd45b25106c",
+      "scope": "upload_run",
+      "created_at": 1499314941
+    }
+    ```
+    Success! `access_token` is your OAuth token for the user. Use it in your API requests to act on behalf of the user
+    by including this header in your requests:
+    ```http
+    Bearer: OAuth YOUR_ACCESS_TOKEN
+    ```
+    The access token expires after the duration specified in `expires_in` (measured in seconds). After it expires, you
+    can retrieve a new one with no user intervention using the returned `refresh_token`:
+    ```http
+    POST https://splits.io/oauth/token
+    ```
+    ```http
+    grant_type=refresh_token
+    refresh_token=YOUR_REFRESH_TOKEN
+    ```
+    This will return a new access token (and a new refresh token -- update yours!) in a body format identical to
+    original grant (above).
+
+    This style of expiring access tokens periodically and using refresh tokens to replace them improves security by
+    making it obvious when a user's stolen credentials are in use. See [RFC 6749][rfc6749-6] for more information on
+    refresh tokens.
+
+#### Example 2: My application is an all-JavaScript website
+If your application is an in-browser JavaScript application with little or no logic performed by a backend server, you
+should use OAuth's **implicit grant flow**.
+
+1. On your Splits I/O [settings page][1], set your `redirect_uri` to where you want users to land after going through
+   the authorization flow. For this example, we'll use
+    ```http
+    https://YOUR_WEBSITE/auth/splitsio
+    ```
+    *Hint: Set this to "debug" for now if you don't yet have a page to redirect yourself to.*
+
+    Set your requested scopes to `upload_run`.
+2. When a user wants to grant authorization to your application for their Splits I/O account, send them to a URL like
+    this:
+    ```http
+    https://splits.io/oauth/authorize?response_type=token&scope=upload_run&redirect_uri=https://YOUR_WEBSITE/auth/splitsio&client_id=YOUR_CLIENT_ID
+    ```
+    If the user authorizes your application, they will be redirected to a URL like
+    ```http
+    https://YOUR_WEBSITE/auth/splitsio#access_token=YOUR_TOKEN
+    ```
+    Success! `access_token` is your OAuth token for the user. Use it in your API requests to act on behalf of the user
+    by including this header in your requests:
+    ```http
+    Bearer: OAuth YOUR_ACCESS_TOKEN
+    ```
+    The access token expires after the duration specified in `expires_in` (measured in seconds). After it expires, you
+    can retrieve a new one with no user intervention using redirection upon accessing your app, or a hidden iframe to
+    invisibly take the user through the authorization flow. If the user is still authorized, no user interaction will be
+    required and you can strip your new access token from the URL fragment.
+
+    This style of expiring access tokens periodically improves security by limiting the usability of any stolen
+    credentials.
+
+#### Example 3: My application is a website
+If your application is a website with a backend component, you should use OAuth's **authorization code grant flow**.
+This means your website will link the user to the Splits I/O authorization page, and if the user accepts the
+authorization, Splits I/O will give your application a `code` which it will immediately exchange for an OAuth token
+using a secure API request.
+
+1. On your Splits I/O [settings page][1], set your `redirect_uri` to where you want users to land after going through
+   the authorization flow. For this example, we'll use
+    ```http
+    https://YOUR_WEBSITE/auth/splitsio
+    ```
+    *Hint: Set this to "debug" for now if you don't yet have a page to redirect yourself to.*
+
+    Set your requested scopes to `upload_run`.
+2. When a user wants to grant authorization to your application for their Splits I/O account, send them to a URL like
+    this:
+    ```http
+    https://splits.io/oauth/authorize?response_type=code&scope=upload_run&redirect_uri=https://YOUR_WEBSITE/auth/splitsio&client_id=YOUR_CLIENT_ID
+    ```
+    If the user authorizes your application, they will be redirected to a URL like
+    ```http
+    https://YOUR_WEBSITE/auth/splitsio?code=YOUR_CODE
+    ```
+    Strip the `code` URL parameter for the next step.
+4. Use your `code` to make this request:
+    ```http
+    POST https://splits.io/oauth/token
+    ```
+    with this body:
+    ```http
+    grant_type=authorization_code
+    client_id=YOUR_CLIENT_ID
+    client_secret=YOUR_CLIENT_SECRET
+    code=YOUR_CODE
+    redirect_uri=http://localhost:8000/auth/splitsio
+    ```
+    which will respond with something like this:
+    ```json
+    {
+      "access_token": "0e82e0ac69fed3c6e5044682a9eb94ccded5ace70e84838104a131cb50595cd2",
+      "token_type": "bearer",
+      "expires_in": 7200,
+      "refresh_token": "0e23b095e0d0104ff0642cde71b61d236f3b3865734a0e734714ecd45b25106c",
+      "scope": "upload_run",
+      "created_at": 1499314941
+    }
+    ```
+    Success! `access_token` is your OAuth token for the user. Use it in your API requests to act on behalf of the user
+    by including this header in your requests:
+    ```http
+    Bearer: OAuth YOUR_ACCESS_TOKEN
+    ```
+    The access token expires after the duration specified in `expires_in` (measured in seconds). After it expires, you
+    can retrieve a new one with no user intervention using the returned `refresh_token`:
+    ```http
+    POST https://splits.io/oauth/token
+    ```
+    ```http
+    grant_type=refresh_token
+    refresh_token=YOUR_REFRESH_TOKEN
+    ```
+    This will return a new access token (and a new refresh token -- update yours!) in a body format identical to
+    original grant (above).
+
+    This style of expiring access tokens periodically and using refresh tokens to replace them improves security by
+    making it obvious when a user's stolen credentials are in use. See [RFC 6749][rfc6749-6] for more information on
+    refresh tokens.
+
+[1]: https://splits.io/settings
+[rfc6749-6]: https://tools.ietf.org/html/rfc6749#section-6
+

--- a/docs/api.md
+++ b/docs/api.md
@@ -372,8 +372,8 @@ want to learn more about OAuth or need general OAuth troubleshooting help, you c
 your application is a website, it's likely that the language you're using has well-established libraries that handle
 much of the below OAuth flow for you.
 
-In all cases, you'll need to first go to your Splits I/O account's [settings page][1] and create an application. Add the
-`upload_run` scope to the list of needed scopes, then refer to the relevant section below.
+In all cases, you'll need to first go to your Splits I/O account's [settings page][1] and create an application, then
+refer to the relevant section below.
 
 *Note: Once you have an OAuth token, you can use a request like this to retrieve information about it:*
 ```http
@@ -393,8 +393,6 @@ for an OAuth token using a secure API request.
     http://localhost:8000/auth/splitsio
     ```
     *Hint: Set this to "debug" for now if you don't yet have a page to redirect yourself to.*
-
-    Set your requested scopes to `upload_run`.
 3. When a user wants to grant authorization to your application for their Splits I/O account, send them to a URL like
     this:
     ```http
@@ -460,8 +458,6 @@ should use OAuth's **implicit grant flow**.
     https://YOUR_WEBSITE/auth/splitsio
     ```
     *Hint: Set this to "debug" for now if you don't yet have a page to redirect yourself to.*
-
-    Set your requested scopes to `upload_run`.
 2. When a user wants to grant authorization to your application for their Splits I/O account, send them to a URL like
     this:
     ```http
@@ -496,8 +492,6 @@ using a secure API request.
     https://YOUR_WEBSITE/auth/splitsio
     ```
     *Hint: Set this to "debug" for now if you don't yet have a page to redirect yourself to.*
-
-    Set your requested scopes to `upload_run`.
 2. When a user wants to grant authorization to your application for their Splits I/O account, send them to a URL like
     this:
     ```http

--- a/spec/controllers/api/v3/runs_controller_spec.rb
+++ b/spec/controllers/api/v3/runs_controller_spec.rb
@@ -63,4 +63,66 @@ describe Api::V3::RunsController do
       end
     end
   end
+
+  describe '#create' do
+    let(:run) do
+      create(:run)
+    end
+
+    context 'when given no OAuth token' do
+      subject(:response) { post :create, params: {file: run.file} }
+
+      it '201s' do
+        expect(response).to have_http_status(201)
+      end
+    end
+
+    context 'when given an invalid OAuth token' do
+      subject(:response) { post :create, params: {file: run.file} }
+
+      it '401s' do
+        request.headers['Authorization'] = 'Bearer bad_token'
+
+        expect(response).to have_http_status(401)
+      end
+    end
+
+    context 'when given a valid OAuth token with no scopes' do
+      subject(:response) { post :create, params: {file: run.file} }
+
+      it '403s' do
+        application = Doorkeeper::Application.create(
+          name: 'Test Application',
+          redirect_uri: 'http://localhost:3000/',
+          owner: create(:user)
+        )
+        authorization = Doorkeeper::AccessToken.create(application_id: application.id, resource_owner_id: create(:user))
+        auth_header = "Bearer #{authorization.token}"
+        request.headers['Authorization'] = auth_header
+
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    context 'when given a valid OAuth token with an upload_run scope' do
+      subject(:response) { post :create, params: {file: run.file} }
+
+      it '201s' do
+        application = Doorkeeper::Application.create(
+          name: 'Test Application',
+          redirect_uri: 'http://localhost:3000/',
+          owner: create(:user)
+        )
+        authorization = Doorkeeper::AccessToken.create(
+          application_id: application.id,
+          resource_owner_id: create(:user),
+          scopes: 'upload_run'
+        )
+        auth_header = "Bearer #{authorization.token}"
+        request.headers['Authorization'] = auth_header
+
+        expect(response).to have_http_status(201)
+      end
+    end
+  end
 end

--- a/spec/controllers/api/v4/runs_controller_spec.rb
+++ b/spec/controllers/api/v4/runs_controller_spec.rb
@@ -28,8 +28,8 @@ describe Api::V4::RunsController do
     context 'when given no cookie and no OAuth token' do
       subject(:response) { post :create, params: {file: run.file} }
 
-      it 'returns a 401' do
-        expect(response).to have_http_status 401
+      it 'returns a 201' do
+        expect(response).to have_http_status 201
       end
     end
 

--- a/spec/controllers/api/v4/runs_controller_spec.rb
+++ b/spec/controllers/api/v4/runs_controller_spec.rb
@@ -5,6 +5,81 @@ describe Api::V4::RunsController do
   let(:incorrect_claim_token) { "i don't know him." }
 
   describe '#create' do
+    let(:run) do
+      create(:run)
+    end
+
+    context 'when given a cookie' do
+      subject(:response) { post :create, params: {file: run.file} }
+      let(:u) { build(:user) }
+      before { allow(controller).to receive(:current_user) { u } }
+
+      it 'returns a 201' do
+        expect(response).to have_http_status 201
+      end
+
+      it 'creates a run that belongs to the logged in user' do
+        id = JSON.parse(response.body)['id']
+        run = Run.find36(id)
+        expect(run.user).to eq u
+      end
+    end
+
+    context 'when given no cookie and no OAuth token' do
+      subject(:response) { post :create, params: {file: run.file} }
+
+      it 'returns a 401' do
+        expect(response).to have_http_status 401
+      end
+    end
+
+    context 'when given an invalid OAuth token' do
+      subject(:response) { post :create, params: {file: run.file} }
+
+      it 'returns a 401' do
+        request.headers['Authorization'] = 'Bearer bad_token'
+
+        expect(response).to have_http_status 401
+      end
+    end
+
+    context 'when given a valid OAuth token with no scopes' do
+      subject(:response) { post :create, params: {file: run.file} }
+
+      it 'returns a 403' do
+        application = Doorkeeper::Application.create(
+          name: 'Test Application',
+          redirect_uri: 'http://localhost:3000/',
+          owner: create(:user)
+        )
+        authorization = Doorkeeper::AccessToken.create(application_id: application.id, resource_owner_id: create(:user))
+        auth_header = "Bearer #{authorization.token}"
+        request.headers['Authorization'] = auth_header
+
+        expect(response).to have_http_status 403
+      end
+    end
+
+    context 'when given a valid OAuth token with an upload_run scope' do
+      subject(:response) { post :create, params: {file: run.file} }
+
+      it 'returns a 201' do
+        application = Doorkeeper::Application.create(
+          name: 'Test Application',
+          redirect_uri: 'http://localhost:3000/',
+          owner: create(:user)
+        )
+        authorization = Doorkeeper::AccessToken.create(
+          application_id: application.id,
+          resource_owner_id: create(:user),
+          scopes: 'upload_run'
+        )
+        auth_header = "Bearer #{authorization.token}"
+        request.headers['Authorization'] = auth_header
+
+        expect(response).to have_http_status 201
+      end
+    end
   end
 
   describe '#show' do

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe ApplicationsController do
+  describe '#create' do
+    let(:name) { 'beepy' } # Just name it anything unique so we can check if it exists later
+    let(:user) { build(:user) }
+    subject(:response) do
+      post :create, params: {doorkeeper_application: {name: name, redirect_uri: redirect_uri}}
+    end
+
+    context 'when logged in' do
+      before { allow(controller).to receive(:current_user) { user } }
+
+      context 'when given a valid redirect_uri' do
+        let(:redirect_uri) { 'https://localhost' }
+
+        it 'redirects back' do
+          expect(response).to redirect_to(settings_path)
+        end
+     end
+
+     context 'when given a non-HTTPS redirect URI' do
+       let(:redirect_uri) { 'http://localhost' }
+
+       it 'does not create the application' do
+         expect(Doorkeeper::Application.find_by(name: name)).to be_nil
+       end
+     end
+   end
+
+   context 'when not logged in' do
+     it 'does not create an application' do
+       expect(Doorkeeper::Application.find_by(name: name)).to be_nil
+     end
+   end
+ end
+
+ describe '#destroy' do
+   let(:application) { create(:application) }
+   let(:response) { delete :destroy, params: {application: application.id} }
+
+   context 'when logged in as the owner' do
+     before { allow(controller).to receive(:current_user) { application.owner } }
+
+     it 'redirects back' do
+       expect(response).to redirect_to(settings_path)
+     end
+   end
+
+   context 'when logged in not as the owner' do
+     before { allow(controller).to receive(:current_user) { build(:user) } }
+
+     it 'returns a 403' do
+       expect(response).to have_http_status(403)
+     end
+   end
+
+   context 'when not logged in' do
+     before { allow(controller).to receive(:current_user) { nil } }
+
+     it 'returns a 403' do
+       expect(response).to have_http_status(403)
+     end
+   end
+ end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe SessionsController do
+  describe '#create' do
+    subject(:response) { post :create, params: {provider: 'twitch'} }
+
+    context 'when given a proper user' do
+      let(:env) do
+        {
+          'omniauth.auth' => double(
+            uid: '29798286',
+            info: double(
+              nickname: 'glacials',
+              name: 'Glacials',
+              email: 'qhiiyr@gmail.com',
+              image: ''
+            ),
+            credentials: double(
+              token: ''
+            )
+          )
+        }
+      end
+      before { allow(request).to receive(:env) { env } }
+
+
+      context 'when given an redirect path via OmniAuth origin' do
+        let(:redirect_path) { '/origin-redirect_path' }
+        before { allow(request).to receive(:env) { env.merge('omniauth.origin' => redirect_path) } }
+
+        it 'redirects correctly' do
+          expect(response).to redirect_to(redirect_path)
+        end
+      end
+
+      context 'when given no redirect path' do
+        it 'redirects to root' do
+          expect(response).to redirect_to('/')
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/application_factory.rb
+++ b/spec/factories/application_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :application, class: Doorkeeper::Application do
+    name SecureRandom.uuid
+    redirect_uri 'debug'
+    association :owner, factory: :user
+  end
+end


### PR DESCRIPTION
Become an OAuth provider, letting other programs (like timers) request specific permissions from users (like uploading runs to their account) then receive a token they can use to do just that.

Very high level overview:

- Lets users create and delete applications from their settings page
- Lets users authorize and deauthorize applications to view who they are on Splits I/O (no scope) and upload runs to their account (`upload_runs` scope) by going through an OAuth flow
- Lets API requests to the v3 and v4 run upload endpoints be authenticated with an OAuth token, which will cause the created run to be owned by the user who granted that token

Closes #227.

<img width="1150" alt="screenshot 2017-07-07 02 39 30" src="https://user-images.githubusercontent.com/438911/27947959-97416e82-62bd-11e7-9c31-bb2b52a16160.png"><img width="1148" alt="screenshot 2017-07-07 02 41 25" src="https://user-images.githubusercontent.com/438911/27948014-cb67a9ec-62bd-11e7-80af-147285ba0017.png"><img width="1160" alt="screenshot 2017-07-07 02 44 38" src="https://user-images.githubusercontent.com/438911/27948155-41498306-62be-11e7-9ec2-da99271e2e96.png">
