### PR TITLE
Allow claiming anonymous runs

### DIFF
--- a/app/assets/javascripts/run_claim.coffee
+++ b/app/assets/javascripts/run_claim.coffee
@@ -11,7 +11,7 @@
 activateClaimLink = (claimToken) ->
   if gon.user != null
     claimLink = document.getElementById('claim-nav-link')
-    claimLink.href = window.location.pathname + '?claim_token=' + claimToken
+    claimLink.href = '/' + gon.run.id + '?claim_token=' + claimToken
 
   claimLinkContainer = document.getElementById('claim-nav-link-container')
   claimLinkContainer.style.display = 'inline'
@@ -19,7 +19,7 @@ activateClaimLink = (claimToken) ->
 activateClaimPrompt = (claimToken) ->
   if gon.user != null
     claimPromptButton = document.getElementById('claim-prompt-button')
-    claimPromptButton.href = window.location.pathname + '?claim_token=' + claimToken
+    claimPromptButton.href = '/' + gon.run.id + '?claim_token=' + claimToken
 
   claimPrompt = document.getElementById('claim-prompt')
   claimPrompt.style.display = 'block'
@@ -28,8 +28,8 @@ $ ->
   if gon.run == undefined
     return
 
-  claimTokenKey = 'claim_tokens' + window.location.pathname
-  dismissedClaimTokenKey = 'dismissed_claim_tokens' + window.location.pathname
+  claimTokenKey = 'claim_tokens/' + gon.run.id
+  dismissedClaimTokenKey = 'dismissed_claim_tokens/' + gon.run.id
 
   if gon.run.user != null
     localStorage.removeItem(dismissedClaimTokenKey)

--- a/app/assets/javascripts/run_claim.coffee
+++ b/app/assets/javascripts/run_claim.coffee
@@ -1,0 +1,51 @@
+# Format of possible localStorage values is:
+#
+# Standard Claim Token -- a run uploaded while not logged in
+# "claim_tokens/<run_id>": "<claim_token>"
+# e.g. "claim_tokens/gcb": "wYJm4S9uAAra6TMyzLkvhC5y"
+#
+# Dismissed Claim Token -- a Standard Claim Token whose prompt was dismised in the UI 
+# "dismissed_claim_tokens/<run_id>": "<claim_token>"
+# e.g. "dismissed_claim_tokens/gcb": "wYJm4S9uAAra6TMyzLkvhC5y"
+
+activateClaimLink = (claimToken) ->
+  if gon.user != null
+    claimLink = document.getElementById('claim-nav-link')
+    claimLink.href = window.location.pathname + '?claim_token=' + claimToken
+
+  claimLinkContainer = document.getElementById('claim-nav-link-container')
+  claimLinkContainer.style.display = 'inline'
+
+activateClaimPrompt = (claimToken) ->
+  if gon.user != null
+    claimPromptButton = document.getElementById('claim-prompt-button')
+    claimPromptButton.href = window.location.pathname + '?claim_token=' + claimToken
+
+  claimPrompt = document.getElementById('claim-prompt')
+  claimPrompt.style.display = 'block'
+
+$ ->
+  claimTokenKey = 'claim_tokens' + window.location.pathname
+  dismissedClaimTokenKey = 'dismissed_claim_tokens' + window.location.pathname
+
+  if gon.run.user != null
+    localStorage.removeItem(dismissedClaimTokenKey)
+    localStorage.removeItem(claimTokenKey)
+    return
+
+  claimToken = localStorage.getItem(claimTokenKey)
+  dismissedClaimToken = localStorage.getItem(dismissedClaimTokenKey)
+
+  document.getElementById('dismiss-claim-prompt').addEventListener 'click', ->
+    document.getElementById('claim-prompt').style.display = 'none'
+    localStorage.removeItem(claimTokenKey)
+    localStorage.setItem(dismissedClaimTokenKey, claimToken)
+
+  if claimToken != null
+    activateClaimLink(claimToken)
+    activateClaimPrompt(claimToken)
+    return
+
+  if dismissedClaimToken != null
+    activateClaimLink(dismissedClaimToken)
+    return

--- a/app/assets/javascripts/run_claim.coffee
+++ b/app/assets/javascripts/run_claim.coffee
@@ -25,6 +25,9 @@ activateClaimPrompt = (claimToken) ->
   claimPrompt.style.display = 'block'
 
 $ ->
+  if gon.run == undefined
+    return
+
   claimTokenKey = 'claim_tokens' + window.location.pathname
   dismissedClaimTokenKey = 'dismissed_claim_tokens' + window.location.pathname
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,7 +40,15 @@ class ApplicationController < ActionController::Base
 
   def set_gon
     gon.request = {path: request.path}
-    gon.user = current_user
+
+    if current_user.nil?
+      gon.user = nil
+    else
+      gon.user = {
+        id: current_user.id,
+        name: current_user.name
+      }
+    end
   end
 
   def ssl_configured?

--- a/app/controllers/runs/stats_controller.rb
+++ b/app/controllers/runs/stats_controller.rb
@@ -21,6 +21,16 @@ class Runs::StatsController < Runs::ApplicationController
       attempts: @run.attempts,
       program: @run.program,
     }
+
+    if @run.user.nil?
+      gon.run['user'] = nil
+    else
+      gon.run['user'] = {
+        id: @run.user.id,
+        name: @run.user.name
+      }
+    end
+
     gon.scale_to = @run.duration_milliseconds
   end
 

--- a/app/views/runs/_title.slim
+++ b/app/views/runs/_title.slim
@@ -1,13 +1,73 @@
 h3
-  - if @run.game.present? && @run.category.present?
-    = @run.game
-    =< @run.category
+  - if run.game.present? && run.category.present?
+    = run.game
+    =< run.category
   - else
     = "(no title)"
 h5
-  div = format_milliseconds(@run.duration_milliseconds)
-  - if @run.user.try(:name)
+  div = format_milliseconds(run.duration_milliseconds)
+  - if run.user.try(:name)
     small
-      span by #{link_to @run.user, user_path(@run.user), class: 'stealth-link user-link'}
-      - if @run.user.silver_patron?
+      span by #{link_to run.user, user_path(run.user), class: 'stealth-link user-link'}
+      - if run.user.silver_patron?
         .gold-split title='Patron'
+h6
+  span#download-menu
+    - timer = Run.program(run.timer)
+    => link_to timer.to_s, download_path(run, timer.to_sym), onclick: 'hide_download_menu()'
+    | &bull;
+    =<> link_to 'LiveSplit One', "https://cryze.github.io/LiveSplitOne/#/splits-io/#{run.id36}", target: '_blank'
+    - (Run.exportable_programs - [Run.program(run.timer)]).each do |timer|
+      | &bull;
+      =<> link_to timer.to_s, download_path(run, timer.to_sym), onclick: 'hide_download_menu()'
+  ul.run-options
+    li
+      a.fake-link#download-link onclick='toggle_download_menu()' ↓ download
+      - if run.category
+        - if !run.belongs_to?(current_user) && current_user.try(:runs?, run.category)
+          li = link_to 'compare to my pb', compare_path(current_user.pb_for(run.category), run)
+        - if run.best_known?
+          li ✓ best on record
+        - elsif run.pb?
+          - if run.belongs_to?(current_user) && run.category.best_known_run.present?
+            li = link_to 'compare to best on record', compare_path(run, run.category.best_known_run)
+          li ✓ pb
+    - if run.srdc_id.present?
+      li = link_to 'speedrun.com', run.srdc_url
+    - if run.video_url.present?
+      li = link_to 'proof', run.video_url
+    li = link_to 'stats', run_stats_path(run)
+    - if can?(:edit, run)
+      li = link_to 'edit', edit_run_path(run)
+    - if run.user.nil?
+      li#claim-nav-link-container style='display: none;'
+        - if current_user.present?
+          = link_to "claim", '#', id: 'claim-nav-link', data: {confirm: "Claim this run as #{current_user.twitch_display_name}?"}
+        - else
+          = link_to "sign in to claim", '/auth/twitch'
+
+article#claim-prompt style='display: none;'
+  .col-md-6.col-md-offset-3
+    .panel.panel-primary
+      .panel-heading
+        | Claim This Run Like a Broken Headlight
+        button#dismiss-claim-prompt type='button' class='close'
+          span aria-hidden='true'
+            .glyphicon.glyphicon-remove
+          span class='sr-only' Close
+      .panel-body
+        - if current_user.nil?
+          p
+            a href='/auth/twitch' Sign in
+            span< to claim this run.
+        - else
+          p You uploaded this run while logged out.
+          p
+            | You can claim it to your account if you'd like (
+            b = current_user.twitch_display_name
+            | ).
+          p
+            .col-md-12
+              .col-md-4.col-md-offset-4
+                a.btn.btn-success.btn-block#claim-prompt-button href='#'
+                  b Claim!

--- a/app/views/runs/show.slim
+++ b/app/views/runs/show.slim
@@ -37,8 +37,41 @@
       li = link_to 'stats', run_stats_path(@run)
       - if can?(:edit, @run)
         li = link_to 'edit', edit_run_path(@run)
+      - if @run.user.nil?
+        li#claim-nav-link-container style='display: none;'
+          - if current_user.present?
+            = link_to "claim", '#', id: 'claim-nav-link', data: {confirm: "Claim this run as #{current_user.twitch_display_name}?"}
+          - else
+            = link_to "sign in to claim", '/auth/twitch'
+
 
 = render partial: 'runs/full_timeline', locals: {run: @run}
+
+article#claim-prompt style='display: none;'
+  .col-md-6.col-md-offset-3
+    .panel.panel-primary
+      .panel-heading
+        | Claim This Run Like a Broken Headlight
+        button#dismiss-claim-prompt type='button' class='close'
+          span aria-hidden='true'
+            .glyphicon.glyphicon-remove
+          span class='sr-only' Close
+      .panel-body
+        - if current_user.nil?
+          p
+            a href='/auth/twitch' Sign in
+            span< to claim this run.
+        - else
+          p You uploaded this run while logged out.
+          p
+            | You can claim it to your account if you'd like (
+            b = current_user.twitch_display_name
+            | ).
+          p
+            .col-md-12
+              .col-md-4.col-md-offset-4
+                a.btn.btn-success.btn-block#claim-prompt-button href='#'
+                  b Claim!
 
 article
   = render partial: 'runs/split_table', locals: {short: @run.short?, splits: @run.splits, comparison_splits: @run.splits}

--- a/app/views/runs/show.slim
+++ b/app/views/runs/show.slim
@@ -9,69 +9,8 @@
       li = link_to @run.category, game_category_path(@run.game, @run.category)
       li = link_to @run.id36, run_path(@run)
   = render partial: 'runs/title', locals: {run: @run}
-  h6
-    span#download-menu
-      - timer = Run.program(@run.timer)
-      => link_to timer.to_s, download_path(@run, timer.to_sym), onclick: 'hide_download_menu()'
-      | &bull;
-      =<> link_to 'LiveSplit One', "https://cryze.github.io/LiveSplitOne/#/splits-io/#{@run.id36}", target: '_blank'
-      - (Run.exportable_programs - [Run.program(@run.timer)]).each do |timer|
-        | &bull;
-        =<> link_to timer.to_s, download_path(@run, timer.to_sym), onclick: 'hide_download_menu()'
-    ul.run-options
-      li
-        a.fake-link#download-link onclick='toggle_download_menu()' ↓ download
-        - if @run.category
-          - if !@run.belongs_to?(current_user) && current_user.try(:runs?, @run.category)
-            li = link_to 'compare to my pb', compare_path(current_user.pb_for(@run.category), @run)
-          - if @run.best_known?
-            li ✓ best on record
-          - elsif @run.pb?
-            - if @run.belongs_to?(current_user) && @run.category.best_known_run.present?
-              li = link_to 'compare to best on record', compare_path(@run, @run.category.best_known_run)
-            li ✓ pb
-      - if @run.srdc_id.present?
-        li = link_to 'speedrun.com', @run.srdc_url
-      - if @run.video_url.present?
-        li = link_to 'proof', @run.video_url
-      li = link_to 'stats', run_stats_path(@run)
-      - if can?(:edit, @run)
-        li = link_to 'edit', edit_run_path(@run)
-      - if @run.user.nil?
-        li#claim-nav-link-container style='display: none;'
-          - if current_user.present?
-            = link_to "claim", '#', id: 'claim-nav-link', data: {confirm: "Claim this run as #{current_user.twitch_display_name}?"}
-          - else
-            = link_to "sign in to claim", '/auth/twitch'
-
 
 = render partial: 'runs/full_timeline', locals: {run: @run}
-
-article#claim-prompt style='display: none;'
-  .col-md-6.col-md-offset-3
-    .panel.panel-primary
-      .panel-heading
-        | Claim This Run Like a Broken Headlight
-        button#dismiss-claim-prompt type='button' class='close'
-          span aria-hidden='true'
-            .glyphicon.glyphicon-remove
-          span class='sr-only' Close
-      .panel-body
-        - if current_user.nil?
-          p
-            a href='/auth/twitch' Sign in
-            span< to claim this run.
-        - else
-          p You uploaded this run while logged out.
-          p
-            | You can claim it to your account if you'd like (
-            b = current_user.twitch_display_name
-            | ).
-          p
-            .col-md-12
-              .col-md-4.col-md-offset-4
-                a.btn.btn-success.btn-block#claim-prompt-button href='#'
-                  b Claim!
 
 article
   = render partial: 'runs/split_table', locals: {short: @run.short?, splits: @run.splits, comparison_splits: @run.splits}

--- a/app/views/runs/stats/index.slim
+++ b/app/views/runs/stats/index.slim
@@ -10,35 +10,6 @@
       li = link_to @run.id36, run_path(@run)
       li = link_to "Statistics", run_stats_path(@run)
   = render partial: 'runs/title', locals: {run: @run}
-  h6
-    span#download-menu
-      - timer = Run.program(@run.timer)
-      => link_to timer.to_s, download_path(@run, timer.to_sym), onclick: 'hide_download_menu()'
-      | &bull;
-      =<> link_to 'LiveSplit One', "https://cryze.github.io/LiveSplitOne/#/splits-io/#{@run.id36}", target: '_blank'
-      - (Run.exportable_programs - [Run.program(@run.timer)]).each do |timer|
-        | &bull;
-        =<> link_to timer.to_s, download_path(@run, timer.to_sym), onclick: 'hide_download_menu()'
-    ul.run-options
-      li
-        a.fake-link#download-link onclick='toggle_download_menu()' ↓ download
-        - if @run.category
-          - if !@run.belongs_to?(current_user) && current_user.try(:runs?, @run.category)
-            li = link_to 'compare to my pb', compare_path(current_user.pb_for(@run.category), @run)
-          - if @run.best_known?
-            li ✓ best on record
-          - elsif @run.pb?
-            - if @run.belongs_to?(current_user) && @run.category.best_known_run.present?
-              li = link_to 'compare to best on record', compare_path(@run, @run.category.best_known_run)
-            li ✓ pb
-      - if @run.srdc_id.present?
-        li = link_to 'speedrun.com', @run.srdc_url
-      - if @run.video_url.present?
-        li = link_to 'proof', @run.video_url
-      li = link_to 'stats', run_stats_path(@run)
-      - if can?(:edit, @run)
-        li = link_to 'edit', edit_run_path(@run)
-
 
 = render partial: 'runs/full_timeline', locals: {run: @run}
 


### PR DESCRIPTION
Allows users to self-claim runs they uploaded while logged out, which is the most common support request I get from people that I have to fulfill manually.

Somehow I had the foresight 2 years ago to add [a single line of code][1] that records claim tokens in localStorage when a run is uploaded, but simultaneously the laziness to waste two years before putting it to any use. So theoretically you can use this feature to claim runs uploaded anonymously ever since.

Would be nice to also have a page that lists claimable runs, but that's more complex.

<img width="634" alt="screenshot 2017-07-11 00 46 36" src="https://user-images.githubusercontent.com/438911/28056649-6f9d334e-65d2-11e7-9708-b22571fdc65c.png">


[1]: https://github.com/glacials/splits-io/commit/191af4635d3d71f4f6cfe8e198ac67e3db676e99#diff-471b2f654e508c40fc08adf4ea19ea00R13