### PR TITLE
Remove depreciation warnings on migrations

### DIFF
--- a/db/migrate/20170616045119_create_doorkeeper_tables.rb
+++ b/db/migrate/20170616045119_create_doorkeeper_tables.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperTables < ActiveRecord::Migration
+class CreateDoorkeeperTables < ActiveRecord::Migration[4.2]
   def change
     create_table :oauth_applications do |t|
       t.string  :name,         null: false

--- a/db/migrate/20170616045820_add_owner_to_application.rb
+++ b/db/migrate/20170616045820_add_owner_to_application.rb
@@ -1,4 +1,4 @@
-class AddOwnerToApplication < ActiveRecord::Migration
+class AddOwnerToApplication < ActiveRecord::Migration[4.2]
   def change
     add_column :oauth_applications, :owner_id, :integer, null: true
     add_column :oauth_applications, :owner_type, :string, null: true


### PR DESCRIPTION
Adds version identifies to the 2 migrations missing them.