### PR TITLE
Add ability to specify accept header to retrieve runs from api

### DIFF
--- a/app/controllers/api/v4/runs_controller.rb
+++ b/app/controllers/api/v4/runs_controller.rb
@@ -2,6 +2,8 @@ class Api::V4::RunsController < Api::V4::ApplicationController
   before_action :set_run, only: [:show, :update, :destroy]
   before_action :verify_ownership!, only: [:update, :destroy]
 
+  before_action :find_accept_header, only: [:show]
+
   before_action :set_link_headers, if: -> { @run.present? }
 
   before_action only: [:create] do
@@ -14,12 +16,8 @@ class Api::V4::RunsController < Api::V4::ApplicationController
   end
 
   def show
-    accept = request.headers.fetch('HTTP_ACCEPT', 'json').downcase
-    if accept == "original_timer"
-      accept = @run.program
-    end
-    timer = Run.program(accept)
-    if accept == 'json' || timer.nil? || !Run.exportable_programs.include?(timer)
+    timer = Run.program_from_content_type(@accept_header)
+    if timer.nil?
       if params[:historic] == '1'
         @run.parse(fast: false)
         render json: @run, serializer: Api::V4::RunWithHistorySerializer
@@ -27,14 +25,11 @@ class Api::V4::RunsController < Api::V4::ApplicationController
         render json: @run, serializer: Api::V4::RunSerializer
       end
     else
+      rendered_run = render_run_to_string(timer)
       send_data(
-        if timer == Run.program(@run.timer)
-          @run.file
-        else
-          render_to_string(file: "runs/#{accept}.html.erb", layout: false)
-        end,
+        rendered_run,
         layout: false,
-        type: "application/#{accept}",
+        type: "#{@accept_header}",
         disposition: 'inline',
         filename: "#{@run.filename(timer: timer)}"
       )
@@ -110,6 +105,30 @@ class Api::V4::RunsController < Api::V4::ApplicationController
        "#{headers['Link']}, #{links}"
     else
       links
+    end
+  end
+
+  def find_accept_header
+    @accept_header = request.headers.fetch('HTTP_ACCEPT', 'application/json').downcase
+    @accept_header = 'application/json' if @accept_header.blank?
+    @accept_header = 'application/json' if @accept_header.include?('text/html')
+    @accept_header = "#{Run.program(@run.timer).content_type}" if @accept_header == 'application/original-timer'
+    valid_accepts = Run.exportable_programs.map(&:content_type) << 'application/json'
+    unless valid_accepts.include?(@accept_header)
+      render status: 406, json: {
+        status: 406,
+        error: "Accept mime type #{@accept_header} not supported",
+        valid_accepts: valid_accepts
+      }
+      return
+    end
+  end
+
+  def render_run_to_string(timer)
+    if timer == Run.program(@run.timer)
+      @run.file
+    else
+      render_to_string(file: "runs/#{@run.program}.html.erb", layout: false)
     end
   end
 

--- a/app/controllers/api/v4/runs_controller.rb
+++ b/app/controllers/api/v4/runs_controller.rb
@@ -128,7 +128,7 @@ class Api::V4::RunsController < Api::V4::ApplicationController
     if timer == Run.program(@run.timer)
       @run.file
     else
-      render_to_string(file: "runs/#{@run.program}.html.erb", layout: false)
+      render_to_string(file: "runs/#{timer.to_sym}.html.erb", layout: false)
     end
   end
 

--- a/app/controllers/api/v4/runs_controller.rb
+++ b/app/controllers/api/v4/runs_controller.rb
@@ -16,7 +16,8 @@ class Api::V4::RunsController < Api::V4::ApplicationController
   def show
     accept = request.headers.fetch('HTTP_ACCEPT', 'json').downcase
     timer = Run.program(accept)
-    if accept == 'json' || timer.nil? || !Run.exportable_programs.include?(timer)
+    json_out = accept == 'json' || timer.nil? || !Run.exportable_programs.include?(timer)
+    if json_out && accept != "original_timer"
       if params[:historic] == '1'
         @run.parse(fast: false)
         render json: @run, serializer: Api::V4::RunWithHistorySerializer
@@ -25,7 +26,7 @@ class Api::V4::RunsController < Api::V4::ApplicationController
       end
     else
       send_data(
-        if timer == Run.program(@run.timer)
+        if timer == Run.program(@run.timer) || accept == 'original_timer'
           @run.file
         else
           render_to_string(file: "runs/#{accept}.html.erb", layout: false)

--- a/app/controllers/api/v4/runs_controller.rb
+++ b/app/controllers/api/v4/runs_controller.rb
@@ -15,9 +15,11 @@ class Api::V4::RunsController < Api::V4::ApplicationController
 
   def show
     accept = request.headers.fetch('HTTP_ACCEPT', 'json').downcase
+    if accept == "original_timer"
+      accept = @run.program
+    end
     timer = Run.program(accept)
-    json_out = accept == 'json' || timer.nil? || !Run.exportable_programs.include?(timer)
-    if json_out && accept != "original_timer"
+    if accept == 'json' || timer.nil? || !Run.exportable_programs.include?(timer)
       if params[:historic] == '1'
         @run.parse(fast: false)
         render json: @run, serializer: Api::V4::RunWithHistorySerializer
@@ -26,7 +28,7 @@ class Api::V4::RunsController < Api::V4::ApplicationController
       end
     else
       send_data(
-        if timer == Run.program(@run.timer) || accept == 'original_timer'
+        if timer == Run.program(@run.timer)
           @run.file
         else
           render_to_string(file: "runs/#{accept}.html.erb", layout: false)

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -53,6 +53,13 @@ class Run < ApplicationRecord
       h[string_or_symbol.to_s]
     end
 
+    def program_from_content_type(content_type_string)
+      Run.exportable_programs.each do |prg|
+        return prg if prg.content_type == content_type_string
+      end
+      return nil
+    end
+
     alias_method :find10, :find
     def find36(id36)
       find10(id36.to_i(36))

--- a/docs/api_v4.md
+++ b/docs/api_v4.md
@@ -46,10 +46,22 @@ If a `historic=1` param is included in the request, one additional field will be
 |-------------:|:---------------------------------------------|:------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `history`    | array of numbers                             | never                                                 | Ordered durations of all previous runs. The first item is the first run recorded by the runner's timer into the source file. The last item is the most recent one. This field is only nonempty if the source timer records history.           |
 
-If an `Accept` header is present, splits.io will try to render the run file natively not in JSON of the type specified.  The format for the header is `application/timer`, with timer being any of the timers that can be exported by splits.io.
-If the `Accept` header is valid, the `Content-type` header in the response will be in the format `application/timer`, with timer being the specified timer.  If the `Accept` header is not valid, the `Content-type` header of the response
-will be `application/json`, and the status code will be a 406.  In the reponse there will be an array of values that can be rendered.  If no `Accept` header is present or `text/html` is contained in the header, JSON will be rendered.
-You may also specify `application/original-timer`, which will output the run file as is with a `Content-type` header with the run's original timer.
+If an `Accept` header is present, Splits I/O will try to render the run file in the format specified rather than JSON. A full list of valid values is located below.
+The format for the header is `application/<timer>`, with `<timer>` being any of the timers that can be exported by Splits I/O.
+If the `Accept` header is valid, the `Content-Type` header in the response will be in the format `application/<timer>`, with `<timer>` being the specified timer.  If the `Accept` header is not valid, the `Content-Type` header of the response
+will be `application/json`, and the status code will be a 406. In the reponse there will be an array of values that can be rendered. If no `Accept` header is present JSON will be rendered.
+You may also specify `application/original-timer`, which will output the run file as is with a `Content-Type` header with the run's original timer.
+
+| `Accept` Header                  | Return Format      | Return `Content-Type`            |
+|---------------------------------:|:-------------------|:---------------------------------|
+| None                             | JSON               | `application/json`               |
+| `application/json`               | JSON               | `application/json`               |
+| `application/wsplit`             | WSplit             | `application/wsplit`             |
+| `application/time-split-tracker` | Time Split Tracker | `application/time-split-tracker` |
+| `application/splitterz`          | SplitterZ          | `application/splitterz`          |
+| `application/livesplit`          | LiveSplit          | `application/livesplit`          |
+| `application/urn`                | Urn                | `application/urn`                |
+| `application/original-timer`     | Original Run File  | The above timers `Content-Type`  |
 
 ### Splits
 ```bash

--- a/docs/api_v4.md
+++ b/docs/api_v4.md
@@ -46,6 +46,11 @@ If a `historic=1` param is included in the request, one additional field will be
 |-------------:|:---------------------------------------------|:------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `history`    | array of numbers                             | never                                                 | Ordered durations of all previous runs. The first item is the first run recorded by the runner's timer into the source file. The last item is the most recent one. This field is only nonempty if the source timer records history.           |
 
+If an `Accept` header is present, splits.io will try to render the run file natively not in JSON of the type specified.  The format for the header is `application/timer`, with timer being any of the timers that can be exported by splits.io.
+If the `Accept` header is valid, the `Content-type` header in the response will be in the format `application/timer`, with timer being the specified timer.  If the `Accept` header is not valid, the `Content-type` header of the response
+will be `application/json`, and the status code will be a 406.  In the reponse there will be an array of values that can be rendered.  If no `Accept` header is present or `text/html` is contained in the header, JSON will be rendered.
+You may also specify `application/original-timer`, which will output the run file as is with a `Content-type` header with the run's original timer.
+
 ### Splits
 ```bash
 curl https://splits.io/api/v4/runs/3nm/splits

--- a/docs/api_v4.md
+++ b/docs/api_v4.md
@@ -47,10 +47,9 @@ If a `historic=1` param is included in the request, one additional field will be
 | `history`    | array of numbers                             | never                                                 | Ordered durations of all previous runs. The first item is the first run recorded by the runner's timer into the source file. The last item is the most recent one. This field is only nonempty if the source timer records history.           |
 
 If an `Accept` header is present, Splits I/O will try to render the run file in the format specified rather than JSON. A full list of valid values is located below.
-The format for the header is `application/<timer>`, with `<timer>` being any of the timers that can be exported by Splits I/O.
-If the `Accept` header is valid, the `Content-Type` header in the response will be in the format `application/<timer>`, with `<timer>` being the specified timer.  If the `Accept` header is not valid, the `Content-Type` header of the response
-will be `application/json`, and the status code will be a 406. In the reponse there will be an array of values that can be rendered. If no `Accept` header is present JSON will be rendered.
-You may also specify `application/original-timer`, which will output the run file as is with a `Content-Type` header with the run's original timer.
+If the `Accept` header is valid, the `Content-Type` header in the response will be set appropriately and the run will be rendered in the specified format, if
+an invalid `Accept` header is supplied, the response `Content-Type` header will be `application/json`, and the status code will be a 406.
+In the 406 reponse there will be an array of values that can be rendered.
 
 | `Accept` Header                  | Return Format      | Return `Content-Type`            |
 |---------------------------------:|:-------------------|:---------------------------------|
@@ -61,7 +60,7 @@ You may also specify `application/original-timer`, which will output the run fil
 | `application/splitterz`          | SplitterZ          | `application/splitterz`          |
 | `application/livesplit`          | LiveSplit          | `application/livesplit`          |
 | `application/urn`                | Urn                | `application/urn`                |
-| `application/original-timer`     | Original Run File  | The above timers `Content-Type`  |
+| `application/original-timer`     | Original Run File  | The above timer's `Content-Type` |
 
 ### Splits
 ```bash

--- a/lib/parsers/livesplit.rb
+++ b/lib/parsers/livesplit.rb
@@ -17,6 +17,10 @@ module LiveSplit
     'http://livesplit.org/'
   end
 
+  def self.content_type
+    'application/livesplit'
+  end
+
   class Parser
     def tugnut_parse(xml, fast: true)
       Tugnut.parse(xml)

--- a/lib/parsers/llanfair.rb
+++ b/lib/parsers/llanfair.rb
@@ -15,6 +15,10 @@ module Llanfair
     'http://jenmaarai.com/llanfair/en/'
   end
 
+  def self.content_type
+    'application/llanfair'
+  end
+
   class Parser
     def parse(file, options = {})
       run = {

--- a/lib/parsers/llanfair_gered.rb
+++ b/lib/parsers/llanfair_gered.rb
@@ -17,6 +17,10 @@ module LlanfairGered
     'https://github.com/gered/Llanfair'
   end
 
+  def self.content_type
+    'application/llanfair-gered'
+  end
+
   class Parser
     def parse(xml, fast: true)
       xml = Nokogiri::XML(xml)

--- a/lib/parsers/splitterz.rb
+++ b/lib/parsers/splitterz.rb
@@ -15,6 +15,10 @@ module SplitterZ
     'http://splitterz420.blogspot.com/'
   end
 
+  def self.content_type
+    'application/splitterz'
+  end
+
   class Parser < BabelBridge::Parser
     rule :splitterz_file, :title_line, many?(:splits), :newline?
 

--- a/lib/parsers/time_split_tracker.rb
+++ b/lib/parsers/time_split_tracker.rb
@@ -15,6 +15,10 @@ module TimeSplitTracker
     'https://dunnius.itch.io/time-split-tracker-windows'
   end
 
+  def self.content_type
+    'application/time-split-tracker'
+  end
+
   class Parser < BabelBridge::Parser
     rule :timesplittracker_file, :first_line, :title_line, many?(:splits)
 

--- a/lib/parsers/urn.rb
+++ b/lib/parsers/urn.rb
@@ -15,6 +15,10 @@ module Urn
     'https://github.com/3snowp7im/urn'
   end
 
+  def self.content_type
+    'application/urn'
+  end
+
   class Parser < BabelBridge::Parser
     def parse(json, options = {})
       json = JSON.parse(json)

--- a/lib/parsers/wsplit.rb
+++ b/lib/parsers/wsplit.rb
@@ -15,6 +15,10 @@ module WSplit
     'https://github.com/Nitrofski/WSplit'
   end
 
+  def self.content_type
+    'application/wsplit'
+  end
+
   class Parser < BabelBridge::Parser
     rule :wsplit_file, :title_line, :optional_goal_line, :attempts_line, :offset_line, :size_line, many?(:splits), :icons_line
 

--- a/spec/controllers/api/v4/runs_controller_spec.rb
+++ b/spec/controllers/api/v4/runs_controller_spec.rb
@@ -111,6 +111,23 @@ describe Api::V4::RunsController do
         expect(subject.body).to match_json_schema(:run)
       end
     end
+
+    context 'for an existing run with a custom accept header' do
+      let(:run) { create(:run, :owned, :parsed) }
+      subject(:response) { get :show, params: {run: run.id36} }
+
+      it 'returns a 200' do
+        request.headers["Accept"] = 'wsplit'
+
+        expect(subject).to have_http_status 200
+      end
+
+      it 'returns the correct content-type header' do
+        request.headers["Accept"] = 'wsplit'
+
+        expect(response.content_type).to eq('application/wsplit')
+      end
+    end
   end
 
   describe '#update' do

--- a/spec/controllers/api/v4/runs_controller_spec.rb
+++ b/spec/controllers/api/v4/runs_controller_spec.rb
@@ -112,20 +112,54 @@ describe Api::V4::RunsController do
       end
     end
 
-    context 'for an existing run with a custom accept header' do
+    context 'for an existing run with a valid accept header' do
       let(:run) { create(:run, :owned, :parsed) }
       subject(:response) { get :show, params: {run: run.id36} }
 
       it 'returns a 200' do
-        request.headers["Accept"] = 'wsplit'
+        request.headers["Accept"] = 'application/wsplit'
 
         expect(subject).to have_http_status 200
       end
 
       it 'returns the correct content-type header' do
-        request.headers["Accept"] = 'wsplit'
+        request.headers["Accept"] = 'application/wsplit'
 
         expect(response.content_type).to eq('application/wsplit')
+      end
+    end
+
+    context 'for an existing run with a bogus accept header' do
+      let(:run) { create(:run, :owned, :parsed) }
+      subject(:response) { get :show, params: {run: run.id36} }
+
+      it 'returns a 406' do
+        request.headers["Accept"] = 'application/liversplit'
+
+        expect(subject).to have_http_status 406
+      end
+
+      it 'returns the correct content-type header' do
+        request.headers["Accept"] = 'application/liversplit'
+
+        expect(response.content_type).to eq('application/json')
+      end
+    end
+
+    context 'for an existing run with a valid original timer accept header' do
+      let(:run) { create(:run, :owned, :parsed) }
+      subject(:response) { get :show, params: {run: run.id36} }
+
+      it 'returns a 200' do
+        request.headers["Accept"] = 'application/original-timer'
+
+        expect(subject).to have_http_status 200
+      end
+
+      it 'returns the correct content-type header' do
+        request.headers["Accept"] = 'application/original-timer'
+
+        expect(response.content_type).to eq('application/livesplit')
       end
     end
   end


### PR DESCRIPTION
Closes #74 .  Can also depreciate the CORS headers on `/:run_id/download/:timer`.