### PR TITLE
Change how to fill in Twitch credentials again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,12 @@
 # bundler config.
 /.bundle
 
-# the default SQLite database.
-/db/*.sqlite3
-/db/*.sqlite3-journal
-
 # all logfiles and tempfiles.
 /log/*.log
 /tmp
 
-# uploaded runs, Twitch oauth credentials, etc.
-/private
+# Twitch oauth credentials, etc.
+Dockerfile-development
 
 # precompiled assets
 /public/assets

--- a/README.md
+++ b/README.md
@@ -37,9 +37,14 @@ when asked:
 ```http
 http://localhost:3000/auth/twitch/callback
 ```
-Twitch will give you a client ID and a client secret. Open `Dockerfile` and find the spots to fill in. Then run
+Twitch will give you a client ID and a client secret. Copy `Dockerfile` to a new file before filling it in so you don't
+accidentally commit your changes:
 ```sh
-git update-index --skip-worktree Dockerfile # to avoid accidentally committing your changes
+cp Dockerfile Dockerfile-development
+```
+then open your copy and find the spots to fill in with your new client information. Afterwards, edit
+`docker-compose.yml`'s `dockerfile: Dockerfile` line to point to your copy. Run
+```sh
 docker-compose build
 ```
 before starting the server again and you're set!


### PR DESCRIPTION
Looks like the `--skip-worktree` has a downside where if you change the file, `--skip-worktree` it, then try to checkout another branch, Git may still complain at you that you have unstashed changes and prevent you from checking out. (And `git stash`ing doesn't even include the Dockerfile if it's been `--skip-worktree`d.)

I really like the idea of not needing to do extra stuff to get splits-io running the first time, so I'm going to try out this method where the extra work is still in the getting-login-working step, but is otherwise more like what we used to do.