### PR TITLE
Make search in navbar expand to fill area

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -61,7 +61,7 @@ h2 small
   display: block
 
 #download-menu
-  visibility: hidden  
+  visibility: hidden
   float: left
   margin: 0
   white-space: nowrap
@@ -113,3 +113,14 @@ a
 
 .kill-run-button
   cursor: pointer
+
+@media (min-width: 768px) {
+  #global-nav
+    display: flex !important // !important needed to override bootstrap use of !important
+    & > .col-sm-3
+      flex-grow: 1
+      & > .navbar-form > .input-group
+        display: flex;
+  #game_q
+    flex-grow: 1
+}


### PR DESCRIPTION
The shorter search bar kind of bugged me, especially since it expanded
to full-width in the mobile overflow menu. This uses flexbox to let the
search bar expand to fill the entire area at any window width greater
than or equal to 768px.

Full disclosure: this was NOT tested very well. I could not get Docker
to start locally (on Windows) and thus was only able to test this via
the ol' browser tools. I don't even know if this was the correct
stylesheet to edit.

Here's what it looks like on my local machine, for reference:
![image](https://user-images.githubusercontent.com/1765799/31496405-311f064c-af29-11e7-90be-5dd94d55933a.png)