### PR TITLE
Switch to using puma as the default webserver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 ruby '2.3.4'
 
 git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
   "https://github.com/#{repo_name}.git"
 end
 
@@ -84,18 +84,18 @@ gem 'platform-api'
 
 # javascript
 gem 'bower-rails'
+gem 'c3-rails'
 gem 'clipboard-rails'
 gem 'coffee-rails'
+gem 'd3-rails', '~> 3.5.17'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'js_cookie_rails'
+gem 'momentjs-rails'
 gem 'numeraljs-rails'
 gem 'spinjs-rails'
 gem 'tipsy-rails'
 gem 'underscore-rails'
-gem 'momentjs-rails'
-gem 'd3-rails', '~> 3.5.17'
-gem 'c3-rails'
 
 # models
 gem 'has_secure_token'
@@ -110,9 +110,8 @@ gem 'versionomy'
 gem 'xml-simple'
 
 # server/environment
+gem 'puma'
 gem 'rails', '~> 5'
-gem 'thin'
-gem 'unicorn'
 
 # speediness
 gem 'dalli'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,6 @@ GEM
     concurrent-ruby (1.0.5)
     d3-rails (3.5.17)
       railties (>= 3.1)
-    daemons (1.2.4)
     dalli (2.7.6)
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
@@ -135,7 +134,6 @@ GEM
     doorkeeper (4.2.6)
       railties (>= 4.2)
     erubis (2.7.0)
-    eventmachine (1.2.0.1)
     excon (0.51.0)
     execjs (2.7.0)
     factory_girl (4.7.0)
@@ -225,7 +223,6 @@ GEM
       activerecord
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
-    kgio (2.10.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -293,6 +290,7 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     ptools (1.3.3)
+    puma (3.10.0)
     rack (2.0.3)
     rack-contrib (1.2.0)
       rack (>= 0.9.1)
@@ -336,7 +334,6 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    raindrops (0.17.0)
     rake (12.0.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
@@ -410,10 +407,6 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     temple (0.7.7)
-    thin (1.7.0)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -429,9 +422,6 @@ GEM
       unf_ext
     unf_ext (0.0.7.2)
     unicode-display_width (1.1.0)
-    unicorn (5.1.0)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
     versionomy (0.5.0)
       blockenspiel (~> 0.5)
     websocket-driver (0.6.5)
@@ -498,6 +488,7 @@ DEPENDENCIES
   platform-api
   pry-rails
   ptools
+  puma
   purecss-rails!
   rails (~> 5)
   rails-controller-testing
@@ -512,12 +503,10 @@ DEPENDENCIES
   simplecov
   slim
   spinjs-rails
-  thin
   tipsy-rails
   turbolinks!
   uglifier
   underscore-rails
-  unicorn
   versionomy
   xml-simple
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,47 @@
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum, this matches the default thread size of Active Record.
+#
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
+threads threads_count, threads_count
+
+# Specifies the `port` that Puma will listen on to receive requests, default is 3000.
+#
+port        ENV.fetch("PORT") { 3000 }
+
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch("RAILS_ENV") { "development" }
+
+# Specifies the number of `workers` to boot in clustered mode.
+# Workers are forked webserver processes. If using threads and workers together
+# the concurrency of the application would be max `threads` * `workers`.
+# Workers do not work on JRuby or Windows (both of which do not support
+# processes).
+#
+# workers ENV.fetch("WEB_CONCURRENCY") { 1 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory. If you use this option
+# you need to make sure to reconnect any threads in the `on_worker_boot`
+# block.
+#
+# preload_app!
+
+# The code in the `on_worker_boot` will be called if you are using
+# clustered mode by specifying a number of `workers`. After each worker
+# process is booted this block will be run, if you are using `preload_app!`
+# option you will want to use this block to reconnect to any threads
+# or connections that may have been created at application boot, Ruby
+# cannot share connections between processes.
+#
+# on_worker_boot do
+#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+# end
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart


### PR DESCRIPTION
Puma is the new default server in rails 5.  This commit also fixes all but one rubocop error in the gemfile