### PR TITLE
Move livesplit-core Repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ docker-compose build
 to rebuild the Docker image for your changes to apply.
 
 ## Parsing
-Split I/O uses [livesplit-core][livesplit-core] for parsing. The parser is located in `lib/parser/*`.
+Splits I/O uses [livesplit-core][livesplit-core] for parsing. The parser is located in `lib/parser/*`.
 To upgrade the parser, simply run `docker-compose run web bundle exec rake update_lsc` and commit the changes.
 
-[livesplit-core]: https://github.com/CryZe/livesplit-core/
+[livesplit-core]: https://github.com/LiveSplit/livesplit-core/

--- a/app/views/runs/_title.slim
+++ b/app/views/runs/_title.slim
@@ -45,7 +45,7 @@ h6
     - timer = Run.program(run.timer)
     => link_to timer.to_s, download_path(run, timer.to_sym), onclick: 'hide_download_menu()'
     | &bull;
-    =<> link_to 'LiveSplit One', "https://cryze.github.io/LiveSplitOne/#/splits-io/#{run.id36}", target: '_blank'
+    =<> link_to 'LiveSplit One', "https://livesplit.github.io/LiveSplitOne/#/splits-io/#{run.id36}", target: '_blank'
     - (Run.exportable_programs - [Run.program(run.timer)]).each do |timer|
       | &bull;
       =<> link_to timer.to_s, download_path(run, timer.to_sym), onclick: 'hide_download_menu()'

--- a/lib/tasks/livesplit_core.rake
+++ b/lib/tasks/livesplit_core.rake
@@ -3,7 +3,7 @@ require 'rubygems/package'
 require 'zlib'
 require 'httparty'
 
-LIVESPLIT_CORE_URL = "https://api.github.com/repos/cryze/livesplit-core/releases/latest"
+LIVESPLIT_CORE_URL = "https://api.github.com/repos/LiveSplit/livesplit-core/releases/latest"
 PARSER_FOLDER = "#{Rake.application.original_dir}/lib/parser"
 DEST_FOLDER = "#{Rake.application.original_dir}/lib/parser/livesplit-core"
 CURRENT_LSC_VERSION = open("#{PARSER_FOLDER}/livesplit_core_version", "r") {|f| f.read }


### PR DESCRIPTION
We just moved it over to the LiveSplit GitHub Organization, so splits.io should use these updated URLs too.