### PR TITLE
Optimize run delete queries

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -19,7 +19,9 @@ class Run < ApplicationRecord
   belongs_to :category
   has_one :game, through: :category
   has_many :segments, dependent: :destroy
-  has_many :histories, class_name: 'RunHistory', dependent: :destroy
+  # dependent: :destroy_all requires there be no child records that need to be deleted
+  # If RunHistory is changed to have child records, change this back to just :destroy
+  has_many :histories, class_name: 'RunHistory', dependent: :delete_all
 
   has_secure_token :claim_token
 

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -19,7 +19,7 @@ class Run < ApplicationRecord
   belongs_to :category
   has_one :game, through: :category
   has_many :segments, dependent: :destroy
-  # dependent: :destroy_all requires there be no child records that need to be deleted
+  # dependent: :delete_all requires there be no child records that need to be deleted
   # If RunHistory is changed to have child records, change this back to just :destroy
   has_many :histories, class_name: 'RunHistory', dependent: :delete_all
 

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -1,6 +1,8 @@
 class Segment < ApplicationRecord
   belongs_to :run
-  has_many :histories, class_name: 'SegmentHistory', dependent: :destroy
+  # dependent: :destroy_all requires there be no child items that need to be deleted
+  # If SegmentHistory is changed to have child records, change this back to just :destroy
+  has_many :histories, class_name: 'SegmentHistory', dependent: :delete_all
 
   default_scope { order(segment_number: :asc) }
 

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -1,6 +1,6 @@
 class Segment < ApplicationRecord
   belongs_to :run
-  # dependent: :destroy_all requires there be no child items that need to be deleted
+  # dependent: :delete_all requires there be no child items that need to be deleted
   # If SegmentHistory is changed to have child records, change this back to just :destroy
   has_many :histories, class_name: 'SegmentHistory', dependent: :delete_all
 


### PR DESCRIPTION
This will delete all the child records by not instantiating the child records but instead deleting all of them with one query.  This means that child records of those will not be removed, but because there are no child records this doesn't apply to us.  In the even they do have child records in the future I left a comment right above it to make it clear that it needs to be changed in the event child records are added.