### PR TITLE
Optimize title partial rendering time

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,7 +6,8 @@ class Ability
 
     can :read, [Run, Category, Game, User]
 
-    can [:update, :create, :destroy], Run.owned, user_id: user.id
+    can [:update, :create, :destroy], Run, user_id: user.id
+    cannot [:update, :create, :destroy], Run, user_id: nil
     can [:read, :update, :create, :destroy], Rivalry, from_user_id: user.id
     can [:destroy], Doorkeeper::Application, owner_id: user.id
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
   end
 
   def runs?(category)
-    runs.where(category: category).present?
+    !runs.where(category: category).empty?
   end
 
   def to_s

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,13 +27,11 @@ class User < ApplicationRecord
   scope :that_run, ->(category) { joins(:runs).where(runs: {category: category}).distinct }
 
   def self.search(term)
-    where(User.arel_table[:name].matches "%#{term}%").joins(:runs).uniq.order(:name)
+    where(User.arel_table[:name].matches("%#{term}%")).joins(:runs).uniq.order(:name)
   end
 
   def avatar
-    if read_attribute(:avatar).nil?
-      return nil
-    end
+    return nil if read_attribute(:avatar).nil?
 
     URI.parse(read_attribute(:avatar) || '').tap do |uri|
       uri.scheme = 'https'
@@ -41,7 +39,7 @@ class User < ApplicationRecord
   end
 
   def uri
-    URI::parse("http://www.twitch.tv/#{name}")
+    URI.parse("http://www.twitch.tv/#{name}")
   end
 
   def to_param
@@ -71,33 +69,25 @@ class User < ApplicationRecord
   end
 
   def patron?
-    if patreon.nil?
-      return false
-    end
+    return false if patreon.nil?
 
-    patreon.pledge_cents > 0
+    patreon.pledge_cents.positive?
   end
 
   def bronze_patron?
-    if patreon.nil?
-      return false
-    end
+    return false if patreon.nil?
 
     patreon.pledge_cents >= 200
   end
 
   def silver_patron?
-    if patreon.nil?
-      return false
-    end
+    return false if patreon.nil?
 
     patreon.pledge_cents >= 400
   end
 
   def gold_patron?
-    if patreon.nil?
-      return false
-    end
+    return false if patreon.nil?
 
     patreon.pledge_cents >= 600
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,7 @@ class User < ApplicationRecord
   end
 
   def runs?(category)
-    !runs.where(category: category).empty?
+    runs.where(category: category).any?
   end
 
   def to_s

--- a/app/views/runs/_title.slim
+++ b/app/views/runs/_title.slim
@@ -1,9 +1,5 @@
 h3
-  - if run.game.present? && run.category.present?
-    = run.game
-    =< run.category
-  - else
-    = "(no title)"
+  = run.to_s
 - if run.completed?(Run::REAL) && run.completed?(Run::GAME)
   = render partial: 'runs/timing_switch', locals: {timing: timing}
 h5


### PR DESCRIPTION
I had noticed that it seemed to be taking the majority of the wall clock time spent for all pages that had the title partial, so I spoofed ~11k runs locally to get larger search times locally.  This change reduced render times ~50% (usually 550ms -> 250ms) since it didn't have to load all the runs and I believe it also skips converting the active record collection to a ruby array to perform `present?`.

I also cleaned up the run title code on the title partial since it was basically duplicated since `Run.to_s` was implemented.