### PR TITLE
Save gametime_duration_ms for each segment history entry

### DIFF
--- a/app/models/concerns/unparsed_run.rb
+++ b/app/models/concerns/unparsed_run.rb
@@ -188,7 +188,8 @@ module UnparsedRun
           histories << SegmentHistory.new(
             segment_id: ids[i],
             attempt_number: history[0].to_i,
-            realtime_duration_ms: history[1][:realtime].nil? ? nil : history[1][:realtime] * 1000
+            realtime_duration_ms: history[1][:realtime].nil? ? nil : history[1][:realtime] * 1000,
+            gametime_duration_ms: history[1][:gametime].nil? ? nil : history[1][:gametime] * 1000
           )
         end
       end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -367,6 +367,22 @@ describe Run, type: :model do
           [12, 'H9 U Havelock', 116_235]
         ]
       end
+
+      it 'has the correct realtime segment histories for the last segment' do
+        expect(run.segments.last.histories.map { |s| s.duration_ms(Run::REAL) }).to match_array [
+          0, 126_778, 126_655, 124_846, 155_191, 140_486, 122_007, 143_338, 132_288, 123_207, 177_090, 164_684, 145_047,
+          123_260, 125_012, 147_050, 126_685, 128_863, 141_873, 141_239, 157_672, 136_347, 145_621, 139_113, 148_362,
+          146_256, 125_921, 123_539, 129_806, 138_700, 141_579, 149_764
+        ]
+      end
+
+      it 'has the correct gametime segment histories for the last segment' do
+        expect(run.segments.last.histories.map { |s| s.duration_ms(Run::GAME) }).to match_array [
+          121_211, 0, 120_240, 117_973, 143_557, 129_113, 115_471, 129_568, 120_883, 116_759, 153_910, 140_808, 129_495,
+          115_616, 119_535, 118_088, 120_402, 121_371, 125_620, 129_508, 138_559, 125_248, 129_562, 120_974, 134_318,
+          128_583, 118_413, 117_208, 119_309, 126_549, 135_392, 136_609
+        ]
+      end
     end
   end
 


### PR DESCRIPTION
Turns out we never actually saved these, no wonder they were always 0 in my testing before XD