### PR TITLE
Use sort_by instead of order to reduce queries

### DIFF
--- a/app/controllers/runs/stats_controller.rb
+++ b/app/controllers/runs/stats_controller.rb
@@ -60,7 +60,7 @@ class Runs::StatsController < Runs::ApplicationController
         next if segment.histories.empty?
 
         attempt_number = 1
-        segment.histories.order(attempt_number: :asc).each do |h|
+        segment.histories.sort_by(&:attempt_number).each do |h|
           while h.attempt_number > attempt_number
             row << ''
             attempt_number += 1


### PR DESCRIPTION
Using `order` creates a new sql query for every segment to allow the db to do the sorting, whereas `sort_by` will convert the results from preloading into a standard ruby array and sort.