### PR TITLE
Fix AWS worker error

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -13,5 +13,5 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-production
-    command: bash -c "rm -f /app/tmp/pids/delayed*.pid && bundle exec bin/delayed_job run -n 2"
+    command: bash -c "rm -f /app/tmp/pids/delayed*.pid && ruby bin/delayed_job run -n 2"
     ports: []


### PR DESCRIPTION
When AWS clones in the repo, the `bin/` directory loses its executable status, which causes bundle to error on the binstub.  By passing it to ruby like you would on windows it fixes the error.