### PR TITLE
Update canonical LiveSplit One URL

### DIFF
--- a/app/views/runs/_title.slim
+++ b/app/views/runs/_title.slim
@@ -41,7 +41,7 @@ h6
     - timer = Run.program(run.timer)
     => link_to timer.to_s, download_path(run, timer.to_sym), onclick: 'hide_download_menu()'
     | &bull;
-    =<> link_to 'LiveSplit One', "https://livesplit.github.io/LiveSplitOne/#/splits-io/#{run.id36}", target: '_blank'
+    =<> link_to 'LiveSplit One', "https://one.livesplit.org/#/splits-io/#{run.id36}", target: '_blank'
     - (Run.exportable_programs - [Run.program(run.timer)]).each do |timer|
       | &bull;
       =<> link_to timer.to_s, download_path(run, timer.to_sym), onclick: 'hide_download_menu()'


### PR DESCRIPTION
It's now https://one.livesplit.org/