### PR TITLE
Fix 2 job errors

### DIFF
--- a/lib/speedrundotcom.rb
+++ b/lib/speedrundotcom.rb
@@ -60,8 +60,6 @@ module SpeedrunDotCom
   end
 
   class << self
-    private
-
     def route
       RestClient::Resource.new('http://speedrun.com/api/v1')
     end

--- a/lib/twitch.rb
+++ b/lib/twitch.rb
@@ -32,6 +32,7 @@ class Twitch
         cursor = response['_cursor']
         break if cursor.nil?
       end
+      ids
     end
 
     class << self


### PR DESCRIPTION
Classes don't have any idea about the module they live in, therefore it's not possible for them to be able to access or see private methods of the containing module.

Also I forgot to return ids in the follower job and when I checked I forgot to wipe the follows from the last test run so it appeared to work fine.