### PR TITLE
Fix 2 possible SRDC job errors

### DIFF
--- a/app/models/concerns/srdc_run.rb
+++ b/app/models/concerns/srdc_run.rb
@@ -18,6 +18,7 @@ module SRDCRun
       return if srdc_id.nil? || user.present?
 
       srdc_runner_id = SpeedrunDotCom::Run.runner_id(srdc_id)
+      return if srdc_runner_id.nil?
       twitch_login = SpeedrunDotCom::User.twitch_login(srdc_runner_id)
       return if twitch_login.blank?
 

--- a/lib/speedrundotcom.rb
+++ b/lib/speedrundotcom.rb
@@ -5,7 +5,11 @@ module SpeedrunDotCom
 
   class Run
     def self.runner_id(id)
-      res = get(id)
+      begin
+        res = get(id)
+      rescue RestClient::NotFound
+        return nil
+      end
       body = JSON.parse(res.body)
 
       body['data']['players'][0]['id']
@@ -40,7 +44,11 @@ module SpeedrunDotCom
 
   class User
     def self.twitch_login(id)
-      res = get(id)
+      begin
+        res = get(id)
+      rescue RestClient::NotFound
+        return nil
+      end
       body = JSON.parse(res.body)
 
       Twitch::User.login_from_url(body['data']['twitch']['uri'])

--- a/lib/speedrundotcom.rb
+++ b/lib/speedrundotcom.rb
@@ -26,7 +26,7 @@ module SpeedrunDotCom
 
     def self.url_from_id(id)
       return nil if id.blank?
-      "http://www.speedrun.com/run/#{id}"
+      "https://www.speedrun.com/run/#{id}"
     end
 
     class << self
@@ -50,8 +50,10 @@ module SpeedrunDotCom
         return nil
       end
       body = JSON.parse(res.body)
+      url = body.try(:[], 'data').try(:[], 'twitch').try(:[], 'uri')
+      return nil if url.nil?
 
-      Twitch::User.login_from_url(body['data']['twitch']['uri'])
+      Twitch::User.login_from_url(url)
     end
 
     class << self
@@ -69,7 +71,7 @@ module SpeedrunDotCom
 
   class << self
     def route
-      RestClient::Resource.new('http://speedrun.com/api/v1')
+      RestClient::Resource.new('https://speedrun.com/api/v1')
     end
   end
 end


### PR DESCRIPTION
Rest client throws an error when the resource is not found, and since we cannot guarantee that srdc resources will still exist when users upload the file, this catches the specific error and ignores it, completing the job successfully.

SRDC does not guarantee that twitch name will be set, so account for this and return out nil if it doesn't exist instead of error'ing.

HTTPS because security and why not.