### PR TITLE
Use bash as a language to stop ruby from installing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: bash
 sudo: required
 services:
   - docker


### PR DESCRIPTION
[This comment](https://github.com/travis-ci/travis-ci/issues/5175#issuecomment-215016943) says that bash is supported even if it's not on the list if you don't want a specific language.

This saves 20-30 seconds on average per build.