### PR TITLE
Fix sql depreciations introduced in 5.2

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -61,13 +61,13 @@ class Game < ApplicationRecord
   def popular_categories
     categories.joins(:runs).group('categories.id')
               .having('count(runs.id) >= ' + (Run.where(category: categories).count * 0.05).to_s)
-              .order('count(runs.id) desc')
+              .order(Arel.sql('count(runs.id) desc'))
   end
 
   def unpopular_categories
     categories.joins(:runs).group('categories.id')
               .having('count(runs.id) < ' + (Run.where(category: categories).count * 0.05).to_s)
-              .order('count(runs.id) desc')
+              .order(Arel.sql('count(runs.id) desc'))
   end
 
   # merge_into! changes ownership of all of this game's categories and aliases to the given game, then destroys this

--- a/app/views/runs/edit.slim
+++ b/app/views/runs/edit.slim
@@ -36,7 +36,7 @@ article
               .col-lg-4
                 = f.collection_select( \
                   :category, \
-                  @run.game.present? ? @run.game.categories.group('categories.id').joins(:runs).order('count(runs.id) desc') : [], \
+                  @run.game.present? ? @run.game.categories.group('categories.id').joins(:runs).order(Arel.sql('count(runs.id) desc')) : [], \
                   :id, \
                   :name, \
                   { \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - "4569"
   webpacker:
     build: .
-    command: bash -c "yarn install && bundle exec bin/webpack-dev-server"
+    command: bash -c "yarn install && ruby bin/webpack-dev-server"
     volumes:
       - .:/app
     ports:


### PR DESCRIPTION
Misattributed to pg_search, when previously looked at it was checking the wrong line.

In docker-compose this fixes running the webpack server for my VM.  For some reason with `bundle exec` it throws cannot find ruby.  It effectively does the same thing since the binstub loads everything that it needs