### PR TITLE
Move credentials to uncommittable file

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,0 +1,9 @@
+# This file is just an example.
+# Try `cp`ing it to .env and then using `source` to export its contents from there.
+# Do note that .env is gitignored, so you won't accidentally commit your creds. :)
+
+# Fill in your Twitch client information if you want login/signup to work
+# You can make a Twitch client at https://dev.twitch.tv/dashboard/apps
+
+export TWITCH_CLIENT_ID=fafaf
+export TWITCH_CLIENT_SECRET=fafaf

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@
 yarn-debug.log*
 yarn-error.log*
 .yarn-integrity
+.env
 
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,6 @@ RUN bundle install -j "$(expr "$(getconf _NPROCESSORS_ONLN)" - 1)"
 COPY package.json yarn.lock ./
 RUN yarn install
 
-# Fill in your Twitch client information if you want login/signup to work
-# You can make a Twitch client at https://dev.twitch.tv/dashboard/apps
-ENV TWITCH_CLIENT_ID put_your_client_id_here
-ENV TWITCH_CLIENT_SECRET put_your_client_secret_here
-
 # Play with these if you want
 ENV READ_ONLY_MODE 0
 ENV ENABLE_ADS 0

--- a/README.md
+++ b/README.md
@@ -38,12 +38,15 @@ Use this redirect URI when asked:
 ```http
 http://localhost:3000/auth/twitch/callback
 ```
-Twitch will give you a client ID and a client secret. Open `Dockerfile` and find the spots to fill in. Then run
+Twitch will give you a client ID and a client secret. Put them in `.env` in the same format as `.example.env`. Then run
 ```sh
-git update-index --skip-worktree Dockerfile # to avoid accidentally committing your changes
+source .env
 docker-compose build
 ```
 before starting the server again and you're set!
+
+(If you want to do the source step automatically in the future, use something
+like [`autoenv`](https://github.com/kennethreitz/autoenv).)
 
 ### Debugging
 #### Getting up and running

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 version: '2'
 services:
   web:
+    environment:
+      - TWITCH_CLIENT_ID
+      - TWITCH_CLIENT_SECRET
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Along with README update and addition of `.example.env`. Hooray lower friction! Hooray fewer git shenanigans!