### PR TITLE
Fix dropdowns eating first click

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,6 @@ gem 'dalli'
 gem 'turbolinks', github: 'rails/turbolinks'
 
 # views
-gem 'bootstrap'
 gem 'bootstrap4-kaminari-views'
 gem 'font-awesome-sass', '~> 5.0.9'
 gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,10 +111,6 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
-    bootstrap (4.1.1)
-      autoprefixer-rails (>= 6.0.3)
-      popper_js (>= 1.12.9, < 2)
-      sass (>= 3.5.2)
     bootstrap4-kaminari-views (1.0.0)
       kaminari (>= 0.13)
       rails (>= 3.1)
@@ -290,7 +286,6 @@ GEM
       activerecord (>= 4.2)
       activesupport (>= 4.2)
       arel (>= 6)
-    popper_js (1.12.9)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -451,7 +446,6 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
-  bootstrap
   bootstrap4-kaminari-views
   cancancan
   coffee-rails

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -3,7 +3,6 @@
 @import "purecss/grids-responsive"
 @import "purecss/menus"
 @import headings
-@import bootstrap
 @import "font-awesome-sprockets"
 @import "font-awesome"
 
@@ -23,7 +22,6 @@
 @import timeline
 @import tips
 @import times
-@import toggle
 
 @import vendor/toolkit-inverse.min
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,7 +9,6 @@
 
 import "jquery"
 import "jquery-ujs"
-import "bootstrap"
 import "moment"
 import "underscore"
 import {Spinner} from "spin.js"

--- a/app/views/settings/index.slim
+++ b/app/views/settings/index.slim
@@ -80,7 +80,7 @@
               a.btn.btn-primary href='/settings/applications/new'
                 span> = icon("fas", "plus")
                 | Create Application
-              a.btn.btn-primary target='_blank' href='https://github.com/glacials/splits-io/blob/master/docs/api.md#uploading-runs-on-behalf-of-a-user-1'
+              a.btn.btn-primary target='_blank' href='https://github.com/glacials/splits-io/blob/master/docs/api.md#user-authentication-and-authorization'
                 span> = icon("fas", "file")
                 | View Documentation
             - if current_user.applications.empty?

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -17,7 +17,6 @@ environment.plugins.prepend(
     clipboard: 'clipboard',
     tipsy: 'tipsy',
     "jquery.turbolink": "jquery.turbolinks",
-    "bootstrap-toggle": "bootstrap-toggle"
   })
 )
 
@@ -29,7 +28,6 @@ const aliasConfig = module.exports = {
       clipboard: 'clipboard/dist/clipboard',
       tipsy: 'tipsy/src/javascripts/jquery.tipsy',
       "jquery.turbolinks": 'jquery.turbolinks/vendor/assets/javascripts/jquery.turbolinks',
-      "bootstrap-toggle": 'bootstrap-toggle/js/bootstrap-toggle'
     }
   }
 }

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -11,8 +11,6 @@ environment.plugins.prepend(
     jquery: 'jquery',
     Popper: ['popper.js', 'default'],
     moment: 'moment',
-    d3: 'd3',
-    c3: 'c3',
     underscore: 'underscore',
     clipboard: 'clipboard',
     tipsy: 'tipsy',

--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "private": true,
   "dependencies": {
     "@rails/webpacker": "3.4",
-    "bootstrap": "^4.1.0",
-    "bootstrap-toggle": "^2.2.2",
     "caniuse-lite": "^1.0.30000792",
     "clipboard": "^1.7.1",
     "coffee-loader": "^0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -879,14 +879,6 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap-toggle@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/bootstrap-toggle/-/bootstrap-toggle-2.2.2.tgz#2b88534fc1b998674f877f98ba0d8b5b743e96fe"
-
-bootstrap@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.1.tgz#3aec85000fa619085da8d2e4983dfd67cf2114cb"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
Fixes a bug where dropdown menus eat your first click and do nothing, requiring a second click to actually drop down.

The Dashboard theme apparently bundles base Bootstrap CSS and JS inside itself, so this was caused by us including both base JS and the theme JS, and I don't know specifically what was happening but I'm guessing attaching the same handler twice to a click is generally bad. Removing the base Bootstrap JS fixes the issue.

I also removed some leftover code from bootstrap-toggle, which is the iOS-like realtime/gametime switch currently in production (but no longer in master).

With this fix, master will be in a good state to go to production.