### PR TITLE
Fix env variables not passing on linux when using make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 
 docker-compose := docker-compose
 ifeq ($(detectedOS),Linux)
-  docker-compose := sudo docker-compose
+  docker-compose := sudo -E docker-compose
 endif
 
 build:


### PR DESCRIPTION
Since we use the .env file now, env variables don't pass to sudo normally, which results in them not being set.  This passes the current env variables to the sudo shell.