### PR TITLE
Add a test for every view that didn't have one

### DIFF
--- a/app/views/doorkeeper/authorizations/show.slim
+++ b/app/views/doorkeeper/authorizations/show.slim
@@ -12,7 +12,7 @@ article
               .input-group-btn
                 .btn.btn-primary.clipboard-btn data-clipboard-target="#code"
                   span#copy = icon("fas", "copy")
-                  span#copied style='display: none;' = icon ("fas", "check")
+                  span#copied style='display: none;' = icon("fas", "check")
           coffee:
             clipboard = new Clipboard('.clipboard-btn')
             clipboard.on('success', (e) ->

--- a/app/views/runs/_claim.slim
+++ b/app/views/runs/_claim.slim
@@ -16,7 +16,7 @@ article#claim-prompt style='display: none;'
           p You uploaded this run while logged out.
           p
             | You can claim it to your account if you'd like (
-            b = current_user.twitch_display_name
+            b = current_user.to_s
             | ).
           p
             .col-lg-12

--- a/app/views/runs/_quick_stats.slim
+++ b/app/views/runs/_quick_stats.slim
@@ -1,4 +1,4 @@
-- previous_upload = @run.user.try(:previous_upload_for, @run.category)
+- previous_upload = run.user.try(:previous_upload_for, run.category)
 
 article data-turbolinks-temporary=true
   .row

--- a/spec/views/applications/forbidden_spec.rb
+++ b/spec/views/applications/forbidden_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'applications/forbidden' do
+  it 'renders the forbidden template' do
+    render
+
+    expect(view).to render_template('applications/forbidden')
+  end
+end

--- a/spec/views/applications/new_spec.rb
+++ b/spec/views/applications/new_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'applications/new' do
+  let(:user) { FactoryBot.create(:user) }
+
+  context 'when logged out' do
+    before { allow(view).to receive(:current_user).and_return(nil) }
+
+    it 'renders the new template' do
+      render
+
+      expect(view).to render_template('applications/new')
+    end
+  end
+
+  context 'when logged in' do
+    before { allow(view).to receive(:current_user).and_return(user) }
+
+    it 'renders the new template' do
+      render
+
+      expect(view).to render_template('applications/new')
+    end
+  end
+end

--- a/spec/views/converts/new_spec.rb
+++ b/spec/views/converts/new_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'converts/new' do
+  it 'renders the new template' do
+    render
+
+    expect(view).to render_template('converts/new')
+  end
+end

--- a/spec/views/doorkeeper/authorizations/error_spec.rb
+++ b/spec/views/doorkeeper/authorizations/error_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'doorkeeper/authorizations/error' do
+  let(:user) { FactoryBot.create(:user) }
+
+  context 'when logged out' do
+    before { allow(view).to receive(:current_user).and_return(nil) }
+
+    it 'renders the error template' do
+      render
+
+      expect(view).to render_template('doorkeeper/authorizations/error')
+    end
+  end
+
+  context 'when logged in' do
+    before { allow(view).to receive(:current_user).and_return(user) }
+
+    it 'renders the error template' do
+      assign(:pre_auth, double(error_response: double(body: {error_description: 'testing error'})))
+      render
+
+      expect(view).to render_template('doorkeeper/authorizations/error')
+    end
+  end
+end

--- a/spec/views/doorkeeper/authorizations/new_spec.rb
+++ b/spec/views/doorkeeper/authorizations/new_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'doorkeeper/authorizations/new' do
+  let(:user) { FactoryBot.create(:user) }
+
+  context 'when logged out' do
+    before { allow(view).to receive(:current_user).and_return(nil) }
+
+    it 'renders the new template' do
+      render
+
+      expect(view).to render_template('doorkeeper/authorizations/new')
+    end
+  end
+
+  context 'when logged in' do
+    before { allow(view).to receive(:current_user).and_return(user) }
+
+    it 'renders the new template' do
+      assign(:pre_auth,
+             double(
+               client: double(name: 'test name', uid: 'test_id'),
+               redirect_uri: 'http://localhost',
+               state: 'test_state',
+               scope: 'test_scope',
+               response_type: 'test_response'
+             ))
+      render
+
+      expect(view).to render_template('doorkeeper/authorizations/new')
+    end
+  end
+end

--- a/spec/views/doorkeeper/authorizations/show_spec.rb
+++ b/spec/views/doorkeeper/authorizations/show_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'doorkeeper/authorizations/show' do
+  it 'renders the show template' do
+    render
+
+    expect(view).to render_template('doorkeeper/authorizations/show')
+  end
+end

--- a/spec/views/games/categories/_title_spec.rb
+++ b/spec/views/games/categories/_title_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'games/categories/_title' do
+  let(:category) { FactoryBot.build(:category, :with_runs) }
+
+  it 'renders the title template' do
+    assign(:category, category)
+    assign(:game, category.game)
+    render
+
+    expect(view).to render_template('games/categories/_title')
+  end
+end

--- a/spec/views/games/edit_spec.rb
+++ b/spec/views/games/edit_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'games/edit' do
+  it 'renders the edit template' do
+    assign(:game, FactoryBot.create(:game))
+    render
+
+    expect(view).to render_template('games/edit')
+  end
+end

--- a/spec/views/games/not_found_spec.rb
+++ b/spec/views/games/not_found_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'games/not_found' do
+  it 'renders the not_found template' do
+    render
+
+    expect(view).to render_template('games/not_found')
+  end
+end

--- a/spec/views/pages/faq_spec.rb
+++ b/spec/views/pages/faq_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'pages/faq' do
+  it 'renders the faq page' do
+    render
+
+    expect(view).to render_template('pages/faq')
+  end
+end

--- a/spec/views/pages/read_only_mode_spec.rb
+++ b/spec/views/pages/read_only_mode_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'pages/read_only_mode' do
+  it 'renders the read only mode page' do
+    render
+
+    expect(view).to render_template('pages/read_only_mode')
+  end
+end

--- a/spec/views/rivalries/_category_candidates_spec.rb
+++ b/spec/views/rivalries/_category_candidates_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'rivalries/_category_candidates' do
+  it 'renders category candidates' do
+    user = FactoryBot.create(:user)
+    follow = FactoryBot.create(:user)
+
+    category = FactoryBot.create(:category)
+
+    FactoryBot.create(:run, category: category, user: user)
+    FactoryBot.create(:run, category: category, user: follow)
+
+    allow(view).to receive(:current_user).and_return(user)
+
+    users = double
+    allow(users).to receive(:twitch_followed_users).and_return(follow)
+
+    render
+
+    expect(view).to render_template('rivalries/_category_candidates')
+  end
+end

--- a/spec/views/rivalries/_user_candidates_spec.rb
+++ b/spec/views/rivalries/_user_candidates_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'rivalries/_user_candidates' do
     FactoryBot.create(:run, category: category, user: user)
     FactoryBot.create(:run, category: category, user: follow)
 
-    allow(controller).to receive(:current_user).and_return(user)
+    allow(view).to receive(:current_user).and_return(user)
 
     users = double
     allow(users).to receive(:twitch_followed_users).and_return(users)

--- a/spec/views/rivalries/new_spec.rb
+++ b/spec/views/rivalries/new_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'rivalries/new' do
+  let(:user) { FactoryBot.create(:user) }
+
+  context 'with no category present' do
+    it 'renders the new template' do
+      allow(view).to receive(:current_user).and_return(user)
+      render
+
+      expect(view).to render_template('rivalries/new')
+    end
+  end
+
+  context 'with a category present' do
+    it 'renders the new template' do
+      follow = FactoryBot.create(:user)
+
+      category = FactoryBot.create(:category)
+      assign(:category, category)
+
+      FactoryBot.create(:run, category: category, user: user)
+      FactoryBot.create(:run, category: category, user: follow)
+
+      allow(view).to receive(:current_user).and_return(user)
+
+      users = double
+      allow(users).to receive(:twitch_followed_users).and_return(follow)
+
+      render
+
+      expect(view).to render_template('rivalries/new')
+    end
+  end
+end

--- a/spec/views/runs/_claim_spec.rb
+++ b/spec/views/runs/_claim_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/_claim' do
+  let(:user) { FactoryBot.create(:user) }
+
+  context 'when logged out' do
+    it 'renders the claim template' do
+      allow(view).to receive(:current_user).and_return(nil)
+      render
+
+      expect(view).to render_template('runs/_claim')
+    end
+  end
+
+  context 'when logged in' do
+    it 'renders the claim template' do
+      allow(view).to receive(:current_user).and_return(user)
+      render
+
+      expect(view).to render_template('runs/_claim')
+    end
+  end
+end

--- a/spec/views/runs/_full_timeline_spec.rb
+++ b/spec/views/runs/_full_timeline_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/_full_timeline' do
+  let(:run) do
+    r = FactoryBot.create(:livesplit16_gametime_run)
+    r.parse_into_db
+    r.reload
+    r
+  end
+
+  context 'with realtime timing' do
+    it 'renders the full timeline' do
+      render(
+        partial: 'runs/full_timeline',
+        locals: {
+          run: run,
+          timing: Run::REAL
+        }
+      )
+
+      expect(view).to render_template('runs/_full_timeline')
+    end
+  end
+
+  context 'with gametime timing' do
+    it 'renders the full timeline' do
+      render(
+        partial: 'runs/full_timeline',
+        locals: {
+          run: run,
+          timing: Run::GAME
+        }
+      )
+
+      expect(view).to render_template('runs/_full_timeline')
+    end
+  end
+end

--- a/spec/views/runs/_gold_timeline_spec.rb
+++ b/spec/views/runs/_gold_timeline_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/_gold_timeline' do
+  let(:run) do
+    r = FactoryBot.create(:livesplit16_gametime_run)
+    r.parse_into_db
+    r.reload
+    r
+  end
+
+  context 'with realtime timing' do
+    it 'renders the gold timeline' do
+      render(
+        partial: 'runs/gold_timeline',
+        locals: {
+          run: run,
+          timing: Run::REAL
+        }
+      )
+
+      expect(view).to render_template('runs/_gold_timeline')
+    end
+  end
+
+  context 'with gametime timing' do
+    it 'renders the gold timeline' do
+      render(
+        partial: 'runs/gold_timeline',
+        locals: {
+          run: run,
+          timing: Run::GAME
+        }
+      )
+
+      expect(view).to render_template('runs/_gold_timeline')
+    end
+  end
+end

--- a/spec/views/runs/_quick_stats_spec.rb
+++ b/spec/views/runs/_quick_stats_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/_quick_stats' do
+  let(:run) do
+    r = FactoryBot.create(:livesplit16_gametime_run)
+    r.parse_into_db
+    r.reload
+    r
+  end
+
+  context 'with realtime timing' do
+    it 'renders the quick stats' do
+      render(
+        partial: 'runs/quick_stats',
+        locals: {
+          run: run,
+          timing: Run::REAL
+        }
+      )
+
+      expect(view).to render_template('runs/_quick_stats')
+    end
+  end
+
+  context 'with gametime timing' do
+    it 'renders the quick stats' do
+      render(
+        partial: 'runs/quick_stats',
+        locals: {
+          run: run,
+          timing: Run::GAME
+        }
+      )
+
+      expect(view).to render_template('runs/_quick_stats')
+    end
+  end
+end

--- a/spec/views/runs/_split_table_spec.rb
+++ b/spec/views/runs/_split_table_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/_split_table' do
+  let(:run) do
+    r = FactoryBot.create(:livesplit16_gametime_run)
+    r.parse_into_db
+    r.reload
+    r
+  end
+
+  context 'with realtime timing' do
+    it 'renders the split table' do
+      render(
+        partial: 'runs/split_table',
+        locals: {
+          short: run.short?,
+          run: run,
+          timing: Run::REAL
+        }
+      )
+
+      expect(view).to render_template('runs/_split_table')
+    end
+  end
+
+  context 'with gametime timing' do
+    it 'renders the split table' do
+      render(
+        partial: 'runs/split_table',
+        locals: {
+          run: run,
+          timing: Run::GAME
+        }
+      )
+
+      expect(view).to render_template('runs/_split_table')
+    end
+  end
+end

--- a/spec/views/runs/_timeline_inspector_spec.rb
+++ b/spec/views/runs/_timeline_inspector_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/_timeline_inspector' do
+  let(:run) do
+    r = FactoryBot.create(:livesplit16_gametime_run)
+    r.parse_into_db
+    r.reload
+    r
+  end
+
+  context 'with realtime timing' do
+    it 'renders the timeline inspector' do
+      render(
+        partial: 'runs/timeline_inspector',
+        locals: {
+          run: run,
+          timing: Run::REAL
+        }
+      )
+
+      expect(view).to render_template('runs/_timeline_inspector')
+    end
+  end
+
+  context 'with gametime timing' do
+    it 'renders the timeline inspector' do
+      render(
+        partial: 'runs/timeline_inspector',
+        locals: {
+          run: run,
+          timing: Run::GAME
+        }
+      )
+
+      expect(view).to render_template('runs/_timeline_inspector')
+    end
+  end
+end

--- a/spec/views/runs/_timeline_spec.rb
+++ b/spec/views/runs/_timeline_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/_timeline' do
+  let(:run) do
+    r = FactoryBot.create(:livesplit16_gametime_run)
+    r.parse_into_db
+    r.reload
+    r
+  end
+
+  context 'with realtime timing' do
+    it 'renders the timeline' do
+      render(
+        partial: 'runs/timeline',
+        locals: {
+          run: run,
+          timing: Run::REAL
+        }
+      )
+
+      expect(view).to render_template('runs/_timeline')
+    end
+  end
+
+  context 'with gametime timing' do
+    it 'renders the timeline' do
+      render(
+        partial: 'runs/timeline',
+        locals: {
+          run: run,
+          timing: Run::GAME
+        }
+      )
+
+      expect(view).to render_template('runs/_timeline')
+    end
+  end
+end

--- a/spec/views/runs/_timing_badge_spec.rb
+++ b/spec/views/runs/_timing_badge_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/_timing_badge' do
+  context 'a run with only realtime' do
+    let(:run) do
+      r = FactoryBot.create(:livesplit16_run)
+      r.parse_into_db
+      r.reload
+      r
+    end
+
+    it 'renders the timing badge' do
+      render(
+        partial: 'runs/timing_badge',
+        locals: {
+          run: run,
+          timing: Run::REAL
+        }
+      )
+    end
+  end
+
+  context 'a run with both realtime and gametime' do
+    let(:run) do
+      r = FactoryBot.create(:livesplit16_gametime_run)
+      r.parse_into_db
+      r.reload
+      r
+    end
+
+    it 'renders the timing badge' do
+      render(
+        partial: 'runs/timing_badge',
+        locals: {
+          run: run,
+          timing: Run::GAME
+        }
+      )
+    end
+  end
+end

--- a/spec/views/runs/_title_spec.rb
+++ b/spec/views/runs/_title_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/_title' do
+  let(:run) do
+    r = FactoryBot.create(:livesplit16_gametime_run)
+    r.parse_into_db
+    r.reload
+    r
+  end
+
+  context 'a run with real time' do
+    it 'renders the title template' do
+      render(
+        partial: 'runs/title',
+        locals: {
+          run: run,
+          timing: Run::REAL
+        }
+      )
+
+      expect(view).to render_template('runs/_title')
+    end
+  end
+
+  context 'a run with game time' do
+    it 'renders the title template' do
+      render(
+        partial: 'runs/title',
+        locals: {
+          run: run,
+          timing: Run::GAME
+        }
+      )
+
+      expect(view).to render_template('runs/_title')
+    end
+  end
+end

--- a/spec/views/runs/cant_parse_spec.rb
+++ b/spec/views/runs/cant_parse_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/cant_parse' do
+  it 'renders the cant_parse template' do
+    render
+
+    expect(view).to render_template('runs/cant_parse')
+  end
+end

--- a/spec/views/runs/forbidden_spec.rb
+++ b/spec/views/runs/forbidden_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/forbidden' do
+  it 'renders the forbidden template' do
+    render
+
+    expect(view).to render_template('runs/forbidden')
+  end
+end

--- a/spec/views/runs/not_found_spec.rb
+++ b/spec/views/runs/not_found_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/not_found' do
+  it 'renders the not_found template' do
+    render
+
+    expect(view).to render_template('runs/not_found')
+  end
+end

--- a/spec/views/runs/unauthorized_spec.rb
+++ b/spec/views/runs/unauthorized_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'runs/unauthorized' do
+  it 'renders the unauthorized template' do
+    render
+
+    expect(view).to render_template('runs/unauthorized')
+  end
+end

--- a/spec/views/shared/_ad_spec.rb
+++ b/spec/views/shared/_ad_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'shared/_ad' do
+  context 'while logged out' do
+    before { allow(view).to receive(:current_user).and_return(nil) }
+
+    it 'renders the ad template' do
+      render
+
+      expect(view).to render_template('shared/_ad')
+    end
+  end
+
+  context 'while logged into a non-gold account' do
+    before { allow(view).to receive(:current_user).and_return(FactoryBot.build(:user)) }
+
+    it 'renders the ad template' do
+      render
+
+      expect(view).to render_template('shared/_ad')
+    end
+  end
+
+  context 'while logged into a gold account' do
+    before { allow(view).to receive(:current_user).and_return(FactoryBot.build(:user, permagold: true)) }
+
+    it 'renders the ad template' do
+      render
+
+      expect(view).to render_template('shared/_ad')
+    end
+  end
+end

--- a/spec/views/shared/_alerts_spec.rb
+++ b/spec/views/shared/_alerts_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'shared/_alerts' do
+  context 'with no alerts' do
+    it 'renders the alerts template' do
+      allow(view).to receive(:flash).and_return({})
+      render
+
+      expect(view).to render_template('shared/_alerts')
+    end
+  end
+
+  context 'with alerts' do
+    it 'renders the alerts template' do
+      allow(view).to receive(:flash).and_return(alert: 'alert text', notice: 'notice text')
+      render
+
+      expect(view).to render_template('shared/_alerts')
+    end
+  end
+end

--- a/spec/views/shared/_category_tabs_spec.rb
+++ b/spec/views/shared/_category_tabs_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'shared/_category_tabs' do
+  let(:game) { FactoryBot.create(:game, :with_runs) }
+
+  context 'with a normal link_type' do
+    it 'renders the category tabs' do
+      render(
+        partial: 'shared/category_tabs',
+        locals: {
+          game: game,
+          current_category: game.categories.first,
+          link_type: :normal
+        }
+      )
+
+      expect(view).to render_template('shared/_category_tabs')
+    end
+  end
+
+  context 'with a SoB link_type' do
+    it 'renders the category tabs' do
+      render(
+        partial: 'shared/category_tabs',
+        locals: {
+          game: game,
+          current_category: game.categories.first,
+          link_type: :sum_of_best
+        }
+      )
+
+      expect(view).to render_template('shared/_category_tabs')
+    end
+  end
+end

--- a/spec/views/shared/_favicons_spec.rb
+++ b/spec/views/shared/_favicons_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'shared/_favicons' do
+  it 'renders the favicons template' do
+    render
+
+    expect(view).to render_template('shared/_favicons')
+  end
+end

--- a/spec/views/shared/_follows_spec.rb
+++ b/spec/views/shared/_follows_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'shared/_follows' do
+  let(:user) { FactoryBot.create(:user) }
+
+  it 'renders the follows template' do
+    follow = FactoryBot.create(:user, :with_runs, twitch_id: 1)
+    allow(view).to receive(:current_user).and_return(user)
+    allow(user).to receive(:twitch_followed_users).and_return(follow)
+
+    render
+
+    expect(view).to render_template('shared/_follows')
+  end
+end

--- a/spec/views/shared/_rollbarjs_spec.rb
+++ b/spec/views/shared/_rollbarjs_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'shared/_rollbarjs' do
+  it 'renders the rollbar template' do
+    render
+
+    expect(view).to render_template('shared/_rollbarjs')
+  end
+end

--- a/spec/views/shared/_twitter_card_spec.rb
+++ b/spec/views/shared/_twitter_card_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'shared/_twitter_card' do
+  context 'with no run' do
+    it 'renders the twitter card' do
+      render
+
+      expect(view).to render_template('shared/_twitter_card')
+    end
+  end
+
+  context 'with a run' do
+    let(:run) { FactoryBot.create(:run) }
+
+    it 'renders the twitter card' do
+      render
+
+      expect(view).to render_template('shared/_twitter_card')
+    end
+  end
+end

--- a/spec/views/tools/index_spec.rb
+++ b/spec/views/tools/index_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'tools/index' do
+  let(:user) { FactoryBot.create(:user, :with_runs) }
+
+  context 'with a non-gold account' do
+    it 'renders the index template' do
+      allow(view).to receive(:current_user).and_return(user)
+      render
+
+      expect(view).to render_template('tools/index')
+    end
+  end
+
+  context 'with a gold account' do
+    it 'renders the index template' do
+      user.permagold = true
+      allow(view).to receive(:current_user).and_return(user)
+      render
+
+      expect(view).to render_template('tools/index')
+    end
+  end
+end

--- a/spec/views/users/show_spec.rb
+++ b/spec/views/users/show_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'users/show' do
+  let(:user) { FactoryBot.create(:user, :with_runs) }
+
+  it 'renders the show template' do
+    assign(:user, user)
+    render
+
+    expect(view).to render_template('users/show')
+  end
+end

--- a/spec/views/why/darkmode_spec.rb
+++ b/spec/views/why/darkmode_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'why/darkmode' do
+  it 'renders the darkmode template' do
+    render
+
+    expect(view).to render_template('why/darkmode')
+  end
+end

--- a/spec/views/why/permalinks_spec.rb
+++ b/spec/views/why/permalinks_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'why/permalinks' do
+  it 'renders the permalinks template' do
+    render
+
+    expect(view).to render_template('why/permalinks')
+  end
+end

--- a/spec/views/why/readonly_spec.rb
+++ b/spec/views/why/readonly_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'why/readonly' do
+  it 'renders the darkmode readonly' do
+    render
+
+    expect(view).to render_template('why/readonly')
+  end
+end


### PR DESCRIPTION
Fix one bug, and 2 slight concerns in views as well.

`twitch_display_name` can still technically be nil, so it's best to just use `to_s` to make it use the chain of names set up for a user.

`run` is already passed to the partial as a local, so it makes sense to use that over the `@run` instance variable.