### PR TITLE
Add vendor directory to asset pipeline

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,6 +7,7 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join('app', 'assets', 'stylesheets', 'vendor')
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets


### PR DESCRIPTION
The asset map would cause a 404 in development.  This adds the directory path to the asset pipeline so that it can find the map and serve it.