### PR TITLE
Optimize db queries on the front page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ gem 'cancancan'
 gem 'doorkeeper'
 
 # db
+gem 'active_record_union'
 gem 'activerecord-import'
 gem 'arel'
 gem 'aws-sdk-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
       activemodel (>= 4.1, < 6)
       case_transform (>= 0.2)
       jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
+    active_record_union (1.3.0)
+      activerecord (>= 4.0)
     activejob (5.2.0)
       activesupport (= 5.2.0)
       globalid (>= 0.3.6)
@@ -436,6 +438,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  active_record_union
   activerecord-import
   administrate
   api-pagination (= 4.7)

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -10,7 +10,7 @@ class Game < ApplicationRecord
   has_many :runs, through: :categories
   has_many :users, -> { distinct }, through: :runs
   has_many :runners, -> { distinct }, through: :runs, class_name: 'User'
-  has_many :aliases, class_name: 'GameAlias', dependent: :destroy
+  has_many :aliases, class_name: 'GameAlias', dependent: :restrict_with_exception
 
   after_create :create_initial_alias
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -10,7 +10,7 @@ class Game < ApplicationRecord
   has_many :runs, through: :categories
   has_many :users, -> { distinct }, through: :runs
   has_many :runners, -> { distinct }, through: :runs, class_name: 'User'
-  has_many :aliases, class_name: 'GameAlias', dependent: :restrict_with_exception
+  has_many :aliases, class_name: 'GameAlias'
 
   after_create :create_initial_alias
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -6,11 +6,11 @@ class Game < ApplicationRecord
 
   validates :name, presence: true
 
-  has_many :categories
+  has_many :categories, dependent: :destroy
   has_many :runs, through: :categories
   has_many :users, -> { distinct }, through: :runs
   has_many :runners, -> { distinct }, through: :runs, class_name: 'User'
-  has_many :aliases, class_name: 'GameAlias'
+  has_many :aliases, class_name: 'GameAlias', dependent: :destroy
 
   after_create :create_initial_alias
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,7 +76,7 @@ class User < ApplicationRecord
   end
 
   def rivals
-    User.joins('INNER JOIN rivalries ON rivalries.to_user_id = users.id AND rivalries.from_user_id = 1')
+    User.joins('INNER JOIN rivalries ON rivalries.to_user_id = users.id AND rivalres.from_user_id = ' + id)
         .select('users.*, rivalries.category_id')
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   include RivalUser
   include TwitchUser
 
-  has_many :runs, dependent: :destroy
+  has_many :runs
   has_many :categories, -> { distinct }, through: :runs
   has_many :games, -> { distinct }, through: :runs
 
@@ -39,9 +39,9 @@ class User < ApplicationRecord
 
   # avatar returns the user's avatar, or a default avatar if the user has not set one. It cannot return nil.
   def avatar
-    return 'https://splits.io/logo.svg' if self[:avatar].nil?
+    return 'https://splits.io/logo.svg' if read_attribute(:avatar).nil?
 
-    URI.parse(self[:avatar] || '').tap do |uri|
+    URI.parse(read_attribute(:avatar) || '').tap do |uri|
       uri.scheme = 'https'
     end.to_s
   end
@@ -63,8 +63,8 @@ class User < ApplicationRecord
   end
 
   def pbs
-    Run.where(user: self).select('DISTINCT ON (category_id) *').order('category_id, realtime_duration_ms ASC')
-       .union(Run.where(user: self, category: nil))
+    runs.where.not(category: nil).select('DISTINCT ON (category_id) *').order('category_id, realtime_duration_ms ASC')
+        .union_all(runs.by_category(nil))
   end
 
   def runs?(category)
@@ -76,7 +76,7 @@ class User < ApplicationRecord
   end
 
   def rivals
-    User.joins('INNER JOIN rivalries ON rivalries.to_user_id = users.id AND rivalries.from_user_id = ' + id.to_s)
+    User.joins('INNER JOIN rivalries ON rivalries.to_user_id = users.id AND rivalries.from_user_id = ', id.to_s)
         .select('users.*, rivalries.category_id')
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,11 +75,6 @@ class User < ApplicationRecord
     twitch_display_name || name || 'somebody'
   end
 
-  def rivals
-    User.joins('INNER JOIN rivalries ON rivalries.to_user_id = users.id AND rivalries.from_user_id = ', id.to_s)
-        .select('users.*, rivalries.category_id')
-  end
-
   def twitch_followed_users
     User.joins(:twitch_user_followers).where(twitch_user_follows: {from_user_id: id})
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,7 +76,7 @@ class User < ApplicationRecord
   end
 
   def rivals
-    User.joins('INNER JOIN rivalries ON rivalries.to_user_id = users.id AND rivalres.from_user_id = ' + id)
+    User.joins('INNER JOIN rivalries ON rivalries.to_user_id = users.id AND rivalries.from_user_id = ' + id.to_s)
         .select('users.*, rivalries.category_id')
   end
 

--- a/app/views/runs/index.slim
+++ b/app/views/runs/index.slim
@@ -9,7 +9,7 @@
       span Splits I/O
   - else
     h2 Splits I/O
-  - if logged_in? && current_user.runs.present?
+  - if logged_in? && current_user.runs.any?
     h5 Want some jelly with these PBs?
   - else
     h5
@@ -20,7 +20,7 @@ article
   .row
     .col-lg-12
       - if logged_in?
-        - if current_user.runs.present?
+        - if current_user.runs.any?
           .card.shadow
             = render partial: 'shared/run_table', locals: { \
               runs: current_user.pbs, \

--- a/app/views/shared/_follows.slim
+++ b/app/views/shared/_follows.slim
@@ -2,7 +2,9 @@
   h4 Recent PBs By People You Follow
   .card.col-md-6.p-0
     .list-group
-      - Run.includes(:game, :category, :user).where(user: current_user.twitch_followed_users).where.not(games: {name: [nil, ""]}).order('runs.created_at DESC').limit(10).each do |run|
+      - followed_runs = Run.includes(:game, :category, :user).where(user: current_user.twitch_followed_users).where.not(games: {name: [nil, ""]}).order('runs.created_at DESC').limit(10)
+      - user_runs = current_user.pbs.where(category_id: followed_runs.map(&:category_id))
+      - followed_runs.each do |run|
         = link_to(run, class: 'list-group-item list-group-item-action flex-column align-items-start')
           .media
             = image_tag(run.user.avatar, size: '70x70', class: 'mr-3')
@@ -14,8 +16,8 @@
                 = "#{run.game} #{run.category}"
                 div
                   = format_ms(run.duration_ms(Run::REAL))
-                  - if current_user.runs?(run.category)
-                    - user_pb = current_user.pb_for(run.category)
+                  - user_pb = user_runs.detect { |r| r.category_id == run.category_id }
+                  - if user_pb.present?
                     = " ("
                     = pretty_difference(user_pb.duration_ms(Run::REAL), run.duration_ms(Run::REAL))
                     = ")"

--- a/app/views/shared/_run_table.slim
+++ b/app/views/shared/_run_table.slim
@@ -43,13 +43,13 @@
             - if cols.include?(:rival)
               td.align-right
                 small
-                  - rival = run.user.rivals.detect { |r| r.category_id == run.category_id }
-                  - if rival.present? && rival.pb_for(run.category).present?
-                    - rival_run = rival.pb_for(run.category)
+                  - rivalry = run.user.rivalries.includes(:to_user).detect { |r| r.category_id == run.category_id }
+                  - if rivalry.present? && rivalry.to_user.pb_for(run.category).present?
+                    - rival_run = rivalry.to_user.pb_for(run.category)
                     = link_to compare_path(run, rival_run), class: 'run-link stealth-link' do
                       = pretty_difference(run.duration_ms(Run::REAL), rival_run.duration_ms(Run::REAL))
                       '  against
-                      = user_badge(rival)
+                      = user_badge(rivalry.to_user)
                   - elsif run.category.present?
                     = link_to new_rivalry_path(category: run.category)
                       .text-success = icon('fas', 'plus')

--- a/app/views/shared/_run_table.slim
+++ b/app/views/shared/_run_table.slim
@@ -1,7 +1,7 @@
 - description ||= nil
 - cols ||= [:runner, :time, :name, :rival, :uploaded]
 - runs = order_runs(runs).page(params[:page])
-- if runs.empty?
+- if runs.blank?
   center
     i No runs matched!
 - else
@@ -24,7 +24,7 @@
           - if cols.include?(:uploaded)
             th.align-right = th_sorter('Uploaded', 'created_at')
       tbody
-        - runs.includes(:user).each do |run|
+        - runs.includes(:user, :game, :category).each do |run|
           tr id="run_#{run.id36}"
             - if cols.include?(:owner_controls)
               td.align-right
@@ -43,8 +43,8 @@
             - if cols.include?(:rival)
               td.align-right
                 small
-                  - rival = run.user.rival_for(run.category)
-                  - if rival.present? && rival.runs?(run.category)
+                  - rival = run.user.rivals.detect { |r| r.category_id == run.category_id }
+                  - if rival.present? && rival.pb_for(run.category)
                     - rival_run = rival.pb_for(run.category)
                     = link_to compare_path(run, rival_run), class: 'run-link stealth-link' do
                       = pretty_difference(run.duration_ms(Run::REAL), rival_run.duration_ms(Run::REAL))

--- a/app/views/shared/_run_table.slim
+++ b/app/views/shared/_run_table.slim
@@ -44,7 +44,7 @@
               td.align-right
                 small
                   - rival = run.user.rivals.detect { |r| r.category_id == run.category_id }
-                  - if rival.present? && rival.pb_for(run.category)
+                  - if rival.present? && rival.pb_for(run.category).present?
                     - rival_run = rival.pb_for(run.category)
                     = link_to compare_path(run, rival_run), class: 'run-link stealth-link' do
                       = pretty_difference(run.duration_ms(Run::REAL), rival_run.duration_ms(Run::REAL))


### PR DESCRIPTION
The following is the base line setup: 7 pbs in the table, 2 of which have rivals attached to the category.  There are 3 followed runs, 2 of those have time differentials to show.

With this pr, I was able to shave ~200ms off the load time in dev env (~750ms -> 550ms), and bring the query count way down (42 uncached, 50 total -> 16 uncached, 29 total).

Let me know if you have any questions about my decisions in any parts of the code.  You could technically reduce more calls if you loaded the runs at the same time as loading the rival for the main table, but this seemed like a great start.