### PR TITLE
Add kaminari config

### DIFF
--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  config.max_per_page = 100
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
Sets max_per_page so you can't just increase the page size to infinity.  Currently the api will accept any `per_page` value, essentially allowing pagination to be bypassed.  This sets the `max_per_page` value to be 100, and if a value over that is provided 100 is simply used instead.  The `Per-Page` header in the response will also reflect the final used value if something invalid is provided.