### PR TITLE
Fixes sum depreciation notice and behavior

### DIFF
--- a/app/models/concerns/runner_user.rb
+++ b/app/models/concerns/runner_user.rb
@@ -5,15 +5,13 @@ module RunnerUser
 
   included do
     def s3_bytes_used(since: 100.years.ago)
-      runs.where('created_at > ?', since).sum(0) do |run|
-        begin
-          s3_run_object = $s3_bucket_internal.object("splits/#{run.s3_filename}")
-          s3_run_object.exists? ? s3_run_object.content_length : 0
-        rescue Aws::S3::Errors::Forbidden => e
-          Rollbar.warn(e, 'Missing/forbidden S3 file while counting runs', run_id: run.id, s3_filename: run.s3_filename)
-          0
-        end
-      end
+      runs.where('created_at > ?', since).sum do |run|
+        s3_run_object = $s3_bucket_internal.object("splits/#{run.s3_filename}")
+        s3_run_object.exists? ? s3_run_object.content_length : 0
+      rescue Aws::S3::Errors::Forbidden => e
+        Rollbar.warn(e, 'Missing/forbidden S3 file while counting runs', run_id: run.id, s3_filename: run.s3_filename)
+        0
+      end || 0
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_21_052308) do
+ActiveRecord::Schema.define(version: 2018_08_27_170856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -87,21 +87,6 @@ ActiveRecord::Schema.define(version: 2018_09_21_052308) do
     t.string "shortname"
     t.index ["name"], name: "index_games_on_name"
     t.index ["shortname"], name: "index_games_on_shortname"
-  end
-
-  create_table "google_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "google_id", null: false
-    t.string "access_token", null: false
-    t.datetime "access_token_expires_at", default: "1970-01-01 00:00:00", null: false
-    t.string "name", null: false
-    t.string "email", null: false
-    t.string "first_name", null: false
-    t.string "last_name", null: false
-    t.string "avatar", null: false
-    t.string "url", null: false
-    t.index ["google_id"], name: "index_google_users_on_google_id", unique: true
-    t.index ["user_id"], name: "index_google_users_on_user_id"
   end
 
   create_table "oauth_access_grants", id: :serial, force: :cascade do |t|
@@ -290,7 +275,6 @@ ActiveRecord::Schema.define(version: 2018_09_21_052308) do
   end
 
   add_foreign_key "game_aliases", "games", on_delete: :cascade
-  add_foreign_key "google_users", "users"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "patreon_users", "users"


### PR DESCRIPTION
`sum(0) do` was actually ignoring the 0 already and returning nil, so this fixes the behavior as well as correctly returning 0 from the function.  This also removes the begin statement which is redundant according to rubocop.

I also committed the removing of `google_users` table from schema file since that isn't currently on master, but if you want me to remove it let me know.

Closes #452 