### PR TITLE
Empty ads holder before turbolinks caches page

### DIFF
--- a/app/assets/stylesheets/ads.sass
+++ b/app/assets/stylesheets/ads.sass
@@ -1,4 +1,4 @@
-#carbonads
+#carbonads-holder
   position: static
   display: block
   margin: 1em 1em 1em 0

--- a/app/javascript/ad_cleanup.js
+++ b/app/javascript/ad_cleanup.js
@@ -1,0 +1,3 @@
+document.addEventListener("turbolinks:before-cache", function() {
+  $('#carbonads').empty()
+})

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -26,6 +26,7 @@ import "../cable.js"
 global.App = this.App
 import "../cable/subscriptions/run.js"
 
+import "../ad_cleanup.js"
 import "../convert.js"
 import "../highchart_theme.js"
 import "../gon.js"

--- a/app/views/shared/_ad.slim
+++ b/app/views/shared/_ad.slim
@@ -1,6 +1,6 @@
 - if (current_user.nil? || current_user.should_see_ads?) && (ENV['ENABLE_ADS'] == '1')
   article
-    div#carbonads
+    div#carbonads-holder
       .card
         .card-body
           script async=true type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=splitsio" id="_carbonads_js"


### PR DESCRIPTION
Turns out the ads JS code places a div with the id `carbonads`, so I changed the holder name as well.