### PR TITLE
Expose stdin for web and worker containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ ifeq ($(detectedOS),Linux)
   docker-compose := sudo -E docker-compose
 endif
 
+ifeq ($(container),)
+  container := web
+endif
+
 build:
 	$(docker-compose) build
 
@@ -30,6 +34,10 @@ console:
 
 update_lsc:
 	$(docker-compose) run web bundle exec rake update_lsc
+
+attach:
+	@echo Do not use ctrl + c to exit this session, use ctrl + p then ctrl + q
+	docker attach $(shell docker ps | grep splits-io_$(container)_ | awk '{print $$1}')
 
 clean:
 	$(docker-compose) down

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ console inside the Docker container with
 make console
 ```
 
+#### Attaching to a debugger
+If you use `binding.pry` anywhere in the code, once you hit the breakpoint specified use the command 
+```sh
+make attach
+```
+in another terminal window to attach to it.  To detach, make sure to exit the debug session then use the docker 
+attach escape sequence `ctrl + p` then `ctrl + q`.  
+
+If you need to attach to a container other than `web`, specify a container with the syntax
+```sh
+make attach container=worker
+```
+
 ### Running Tests
 To run tests from inside the Docker container, use
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     environment:
       - TWITCH_CLIENT_ID
       - TWITCH_CLIENT_SECRET
+    stdin_open: true
+    tty: true
   db:
     image: postgres
     volumes:
@@ -51,5 +53,7 @@ services:
       - s3
     links:
       - s3:s3.localhost
+    stdin_open: true
+    tty: true
   redis:
     image: redis


### PR DESCRIPTION
This allows calls to `binding.pry` or `byebug` to be attached to instead of just ignoring them.

To attach to the instance, just run `docker attach splits-io_web_1` for the web instance, or `docker attach splits-io_worker_1`.  You can also attach to the container id found through `docker ps` if those don't work.

To detach from the container you need to exit the debug session so that execution will resume, and then do the attach escape code which is `ctrl + p` followed by `ctrl + q`.  If you do a `ctrl + c` from this you will shut down whatever the running process is (ie the web server or the worker process).