### PR TITLE
Implement file descriptor based parsing

### DIFF
--- a/app/models/concerns/s3_run.rb
+++ b/app/models/concerns/s3_run.rb
@@ -17,6 +17,16 @@ module S3Run
       nil
     end
 
+    def save_locally
+      return if File.exist?("tmp/#{s3_filename}")
+
+      file = $s3_bucket_internal.object("splits/#{s3_filename}")
+      result = file.download_file("tmp/#{s3_filename}")
+      raise 'error downloading file from s3' unless result
+
+      result
+    end
+
     def in_s3?
       file = $s3_bucket_internal.object("splits/#{s3_filename}")
       file.exists?

--- a/app/models/concerns/s3_run.rb
+++ b/app/models/concerns/s3_run.rb
@@ -6,7 +6,10 @@ module S3Run
   included do
     class RunTooLarge < StandardError; end
     class RunDownloadError < StandardError; end
+
     def file
+      # If a block is passed in, a standard File object will be opened, passed to the block, and then closed
+      # If no block is passed, the file will be read into memory from S3 and returned as a string
       file = $s3_bucket_internal.object("splits/#{s3_filename}")
 
       return nil unless file.exists?

--- a/app/models/concerns/unparsed_run.rb
+++ b/app/models/concerns/unparsed_run.rb
@@ -13,10 +13,11 @@ module UnparsedRun
         segments.delete_all
         histories.delete_all
 
-        f = file
-        return false if f.nil?
+        save_locally
+        fd = File.open("tmp/#{s3_filename}")
 
-        parse_result = Parser.parse(f)
+        parse_result = Parser.parse(fd.fileno)
+        fd.close
         return false if parse_result.nil?
         return false if parse_result[:splits].blank?
 

--- a/app/models/concerns/unparsed_run.rb
+++ b/app/models/concerns/unparsed_run.rb
@@ -13,11 +13,13 @@ module UnparsedRun
         segments.delete_all
         histories.delete_all
 
-        save_locally
-        fd = File.open("tmp/#{s3_filename}")
+        parse_result = nil
+        file do |f|
+          return false if f.nil?
 
-        parse_result = Parser.parse(fd.fileno)
-        fd.close
+          parse_result = Parser.parse(f.fileno)
+        end
+
         return false if parse_result.nil?
         return false if parse_result[:splits].blank?
 

--- a/lib/parser/livesplit_core_parser.rb
+++ b/lib/parser/livesplit_core_parser.rb
@@ -5,9 +5,10 @@ rescue LoadError
 end
 
 class Parser
-  def self.parse(run_string, fast: false)
-    parse_result = LiveSplitCore::Run.parse(run_string, run_string.bytesize, '', false)
+  def self.parse(run_file_descriptor, fast: false)
+    parse_result = LiveSplitCore::Run.parse_file_handle(run_file_descriptor, '', false)
     return nil unless parse_result.parsed_successfully
+
     program = parse_result.timer_kind
 
     if Run.program_from_attribute(:to_s, program).nil?

--- a/lib/parser/livesplit_core_parser.rb
+++ b/lib/parser/livesplit_core_parser.rb
@@ -5,15 +5,19 @@ rescue LoadError
 end
 
 class Parser
-  def self.parse(run_file_descriptor, fast: false)
-    parse_result = LiveSplitCore::Run.parse_file_handle(run_file_descriptor, '', false)
+  def self.parse(run, fast: false)
+    parse_result = if run.is_a?(Integer)
+                     # If integer, attempt to parse the file descriptor attached to the number
+                     LiveSplitCore::Run.parse_file_handle(run, '', false)
+                   else
+                     # Assume run is already read into a string and parse from memory
+                     LiveSplitCore::Run.parse(run, run.length, '', false)
+                   end
     return nil unless parse_result.parsed_successfully
 
     program = parse_result.timer_kind
 
-    if Run.program_from_attribute(:to_s, program).nil?
-      program = ExchangeFormat.to_s
-    end
+    program = ExchangeFormat.to_s if Run.program_from_attribute(:to_s, program).nil?
 
     if parse_result.is_generic_timer && !Run.program_from_attribute(:to_s, program).exchangeable?
       # We got a file in the exchange format, but the reported timer doesn't support the exchange format. Wipe the timer


### PR DESCRIPTION
Have `file` method change its behavior if you pass a block to it, so that it returns a file object that you can work with instead of reading the file into memory.  When the block is complete it will then close the file and clean up the tmp file that it saved down.

I also adapted the parser to check the input and if it's a `Integer` use fd parsing, otherwise fall back to the old parsing through memory.  It seemed like a good idea to keep it around for edge cases that way we don't have to add it back later.