### PR TITLE
Have space used respect `since` parameter

### DIFF
--- a/app/helpers/s3_helper.rb
+++ b/app/helpers/s3_helper.rb
@@ -1,6 +1,6 @@
 module S3Helper
   def s3_bytes_used(user, since: 100.years.ago)
-    number_to_human_size(user.s3_bytes_used)
+    number_to_human_size(user.s3_bytes_used(since: since))
   rescue Aws::Waiters::Errors::UnexpectedError => e
     Rollbar.warn(e, 'Unable to fetch S3 bytes')
     '???'


### PR DESCRIPTION
Previously it did not pass in the param in the helper, this just passes it along to the concern.