### PR TITLE
Fix error when delaying highlight suggestion's destroy

### DIFF
--- a/app/models/highlight_suggestion.rb
+++ b/app/models/highlight_suggestion.rb
@@ -36,7 +36,8 @@ class HighlightSuggestion < ApplicationRecord
               }.to_query
             end
           )
-          delay(run_at: video_start + 60.days).destroy # 60 days is life of archives for Partners / Twitch Prime members
+          # 60 days is life of archives for Partners / Twitch Prime members
+          highlight_suggestion.delay(run_at: video_start + 60.days).destroy
           return highlight_suggestion
         end
       end


### PR DESCRIPTION
The current method call is the model object call which expects a parameter of either an id or array of id's to look up and destroy instead of calling it on the object that is meant to be destroyed.