### PR TITLE
[WIP] Change from AMS over to Panko Serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'groupdate'
 gem 'active_model_serializers'
 gem 'api-pagination', '= 4.7'
 gem 'jbuilder'
+gem 'panko_serializer'
 gem 'rack-cors', require: 'rack/cors'
 
 # authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    oj (3.7.8)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
@@ -288,6 +289,8 @@ GEM
       omniauth-oauth2 (~> 1.1)
     order_as_specified (1.5)
       activerecord (>= 5.0.0)
+    panko_serializer (0.5.9)
+      oj (~> 3.7.0)
     parallel (1.13.0)
     parser (2.6.0.0)
       ast (~> 2.4.0)
@@ -500,6 +503,7 @@ DEPENDENCIES
   omniauth-oauth2
   omniauth-twitch
   order_as_specified
+  panko_serializer
   patreon (< 0.3.0)
   pg
   pg_search

--- a/app/controllers/api/v4/runs_controller.rb
+++ b/app/controllers/api/v4/runs_controller.rb
@@ -21,9 +21,11 @@ class Api::V4::RunsController < Api::V4::ApplicationController
     timer = Run.program_from_attribute(:content_type, @accept_header)
     if timer.nil?
       if params[:historic] == '1'
-        render json: @run,
-               serializer: Api::V4::RunSerializer,
-               include: ['game', 'category', 'runners', 'histories', 'segments', 'segments.histories']
+        render(
+          json: Panko::Response.create do |r|
+            {run: r.serializer(@run, ::RunSerializer)}
+          end
+        )
       else
         render json: @run, serializer: Api::V4::RunSerializer, include: %w[game category runners segments]
       end

--- a/app/controllers/api/v4/runs_controller.rb
+++ b/app/controllers/api/v4/runs_controller.rb
@@ -21,11 +21,17 @@ class Api::V4::RunsController < Api::V4::ApplicationController
     timer = Run.program_from_attribute(:content_type, @accept_header)
     if timer.nil?
       if params[:historic] == '1'
-        render(
-          json: Panko::Response.create do |r|
-            {run: r.serializer(@run, ::RunSerializer)}
-          end
-        )
+        if params[:panko] == '1'
+          render(
+            json: Panko::Response.create do |r|
+              {run: r.serializer(@run, ::RunSerializer)}
+            end
+          )
+        else
+          render json: @run,
+                 serializer: Api::V4::RunSerializer,
+                 include: ['game', 'category', 'runners', 'histories', 'segments', 'segments.histories']
+        end
       else
         render json: @run, serializer: Api::V4::RunSerializer, include: %w[game category runners segments]
       end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -156,6 +156,10 @@ class Run < ApplicationRecord
     delay.set_runner_from_srdc
   end
 
+  def runners
+    [user]
+  end
+
   def filename(timer: Run.program(self.timer))
     "#{to_param}.#{timer.file_extension}"
   end

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,0 +1,7 @@
+class CategorySerializer < Panko::Serializer
+  attributes :id, :name, :created_at, :updated_at
+
+  def id
+    object.id.to_s
+  end
+end

--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -1,0 +1,7 @@
+class GameSerializer < Panko::Serializer
+  attributes :name, :shortname, :created_at, :updated_at
+
+  def shortname
+    object.srdc.try(:shortname) || object.srl.try(:shortname)
+  end
+end

--- a/app/serializers/run_history_serializer.rb
+++ b/app/serializers/run_history_serializer.rb
@@ -1,0 +1,3 @@
+class RunHistorySerializer < Panko::Serializer
+  attributes :attempt_number, :realtime_duration_ms, :gametime_duration_ms
+end

--- a/app/serializers/run_serializer.rb
+++ b/app/serializers/run_serializer.rb
@@ -1,0 +1,24 @@
+class RunSerializer < Panko::Serializer
+  attributes :id, :srdc_id, :realtime_duration_ms, :gametime_duration_ms, :default_timing,
+             :realtime_sum_of_best_ms, :gametime_sum_of_best_ms, :program, :attempts, :image_url,
+             :created_at, :updated_at, :video_url
+
+  # Begin associations
+  has_one :game, serializer: GameSerializer
+  has_one :category, serializer: CategorySerializer
+  has_many :runners, serializer: RunnerSerializer
+  has_many :histories, serializer: RunHistorySerializer
+  has_many :segments, serializer: SegmentSerializer
+
+  def id
+    object.id36
+  end
+
+  def runners
+    if object.user.nil?
+      []
+    else
+      [object.user]
+    end
+  end
+end

--- a/app/serializers/runner_serializer.rb
+++ b/app/serializers/runner_serializer.rb
@@ -8,4 +8,8 @@ class RunnerSerializer < Panko::Serializer
   def display_name
     object.to_s
   end
+
+  def avatar
+    object.avatar
+  end
 end

--- a/app/serializers/runner_serializer.rb
+++ b/app/serializers/runner_serializer.rb
@@ -1,0 +1,11 @@
+class RunnerSerializer < Panko::Serializer
+  attributes :twitch_id, :name, :display_name, :avatar, :created_at, :updated_at
+
+  def twitch_id
+    object.twitch.try(:twitch_id).try(:to_s)
+  end
+
+  def display_name
+    object.to_s
+  end
+end

--- a/app/serializers/segment_history_serializer.rb
+++ b/app/serializers/segment_history_serializer.rb
@@ -1,0 +1,11 @@
+class SegmentHistorySerializer < Panko::Serializer
+  attributes :attempt_number, :realtime_duration_ms, :gametime_duration_ms
+
+  def realtime_duration_ms
+    object.realtime_duration_ms || 0
+  end
+
+  def gametime_duration_ms
+    object.gametime_duration_ms || 0
+  end
+end

--- a/app/serializers/segment_serializer.rb
+++ b/app/serializers/segment_serializer.rb
@@ -1,0 +1,9 @@
+class SegmentSerializer < Panko::Serializer
+  attributes  :id, :name, :segment_number,
+              :realtime_start_ms, :realtime_end_ms, :realtime_duration_ms, :realtime_shortest_duration_ms,
+              :realtime_gold, :realtime_reduced, :realtime_skipped,
+              :gametime_start_ms, :gametime_end_ms, :gametime_duration_ms, :gametime_shortest_duration_ms,
+              :gametime_gold, :gametime_reduced, :gametime_skipped
+
+  has_many :histories, serializer: SegmentHistorySerializer
+end


### PR DESCRIPTION
In order to try and speed up the API bit for very large runs, I have been looking for alternatives to AMS that are both more performant and allow us to not have to adopt a completely different returned JSON structure.  As of late I found 2 different ones that both boast better performance, [Blueprinter](https://github.com/procore/blueprinter) and [Panko Serializer](https://github.com/yosiat/panko_serializer).  At first I tried out Blueprinter because the options, config, and feature set seemed quite impressive, but it lacks the ability to set a root node for the emitted JSON which nukes performance and memory usage to basically AMS levels which would mean a side-grade.  Panko on the other hand is billed as a highly performant alternative, with almost all of the exact same features as AMS.  After testing it out a bit with some manual testing and apache bench for some basic tests, I found that it does indeed have much better performance on runs with extremely large histories (small run tested with <100 attempts was nearly identical response time and memory).

As stated, my "highly scientific testing" consisted of pressing f5 in my browser to see render times, and using ab a bit to get a general idea of average response time.  Here are the results:
```
AMS
Server Hostname:        localhost
Server Port:            3000

Document Path:          /api/v4/runs/f?historic=1
Document Length:        14447669 bytes

Concurrency Level:      1
Time taken for tests:   92.062 seconds
Complete requests:      3
Failed requests:        0
Total transferred:      43344777 bytes
HTML transferred:       43343007 bytes
Requests per second:    0.03 [#/sec] (mean)
Time per request:       30687.351 [ms] (mean)
Time per request:       30687.351 [ms] (mean, across all concurrent requests)
Transfer rate:          459.79 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing: 23994 26856 3210.2  28287   30327
Waiting:    23824 26705 3210.6  28146   30166
Total:      23994 26856 3210.2  28287   30327

Percentage of the requests served within a certain time (ms)
  50%  26247
  66%  26247
  75%  30327
  80%  30327
  90%  30327
  95%  30327
  98%  30327
  99%  30327
 100%  30327 (longest request)
```
```
PS
Server Hostname:        localhost
Server Port:            3000

Document Path:          /api/v4/runs/f?historic=1
Document Length:        14447567 bytes

Concurrency Level:      1
Time taken for tests:   130.765 seconds
Complete requests:      10
Failed requests:        0
Total transferred:      144481569 bytes
HTML transferred:       144475670 bytes
Requests per second:    0.08 [#/sec] (mean)
Time per request:       13076.492 [ms] (mean)
Time per request:       13076.492 [ms] (mean, across all concurrent requests)
Transfer rate:          1079.00 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:  9647 13076 2001.5  13823   15671
Waiting:     9490 12925 2009.1  13664   15505
Total:       9647 13076 2001.5  13823   15671

Percentage of the requests served within a certain time (ms)
  50%  13823
  66%  13953
  75%  14537
  80%  15268
  90%  15671
  95%  15671
  98%  15671
  99%  15671
 100%  15671 (longest request)
```

Now you might be asking, why would you stop at 3 requests for AMS?  Well after 3 requests I hit the memory limit of my VM (4gb + 500MB swap) and had to quit the test during the 4th request before it crashed from OoM again like it did the first test.  PS on the other hand was able to finish out all 10 requests, with the last one at the memory usage of the 4th request of AMS.  In my manual testing I found that the mean time of ~25 seconds for AMS was pretty accurate though as it was always right around that time, same with the mean time of ~13 seconds for PS.

Since this would be a large change, before doing any investment into this I wanted to get your feedback and see if this is the direction you wanted to go in.  I have set up the endpoint at `api/v4/runs/:run_id?historic=1&panko=1` to use PS instead of AMS in order to make testing for you a bit easier if you wanted to check it out and confirm my findings.

In case this doesn't appeal to you at all, I still have a Blueprinter branch lying around if you were more interested in that library.  I already opened an issue to see about root nodes, but I'm not sure if they want to include that since it seems more focused on serializing objects and not providing complete responses but who knows.