### PR TITLE
Only delay destroy if highlight suggestion is persisted

### DIFF
--- a/app/models/highlight_suggestion.rb
+++ b/app/models/highlight_suggestion.rb
@@ -1,7 +1,7 @@
 class HighlightSuggestion < ApplicationRecord
   belongs_to :run
 
-  validates_uniqueness_of :run
+  validates :run, uniqueness: true
 
   class << self
     # from_run looks on Twitch for past broadcasts whose timestamps show that it contains the given run's PB. If found,
@@ -37,7 +37,7 @@ class HighlightSuggestion < ApplicationRecord
             end
           )
           # 60 days is life of archives for Partners / Twitch Prime members
-          highlight_suggestion.delay(run_at: video_start + 60.days).destroy
+          highlight_suggestion.delay(run_at: video_start + 60.days).destroy if highlight_suggestion.persisted?
           return highlight_suggestion
         end
       end


### PR DESCRIPTION
At minimum, when reparsing a run it will re-trigger the highlight suggestion which will cause the creation to fail since it "should" get the same response back from Twitch, and find the video but since we validate on uniqueness of run_id this will cause it to not persist the suggestion, which then causes the destroy delay to fail because the object is only contained in memory.