### PR TITLE
Add Speedrun.com category links

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,6 +4,8 @@ class Category < ApplicationRecord
   has_many :users, through: :runs
   has_many :rivalries, dependent: :destroy
 
+  has_one :srdc, class_name: 'SpeedrunDotComCategory', dependent: :destroy
+
   before_create :autodetect_shortname
 
   def self.global_aliases
@@ -46,6 +48,15 @@ class Category < ApplicationRecord
 
   def to_param
     id.to_s
+  end
+
+  def sync_with_srdc
+    if srdc.nil?
+      SpeedrunDotComCategory.from_category!(self)
+      return
+    end
+
+    srdc.sync!
   end
 
   def autodetect_shortname

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -147,6 +147,7 @@ class Run < ApplicationRecord
     return if game.blank?
     game.delay.sync_with_srdc
     game.delay.sync_with_srl
+    category.delay.sync_with_srdc
   end
 
   # If we don't have a user assigned but we do have a speedrun.com run assigned, try to fetch the user from

--- a/app/models/speedrun_dot_com_category.rb
+++ b/app/models/speedrun_dot_com_category.rb
@@ -7,7 +7,7 @@ class SpeedrunDotComCategory < ApplicationRecord
     return category.srdc if category.srdc.present?
 
     if category.game.srdc.nil?
-      srdc_game = SpeedrunDotComGame.from_game!(category.game.srdc.srdc_id).persisted?
+      srdc_game = SpeedrunDotComGame.from_game!(category.game)
       return if srdc_game.nil? || !srdc_game.persisted?
     end
 

--- a/app/models/speedrun_dot_com_category.rb
+++ b/app/models/speedrun_dot_com_category.rb
@@ -1,0 +1,36 @@
+require 'speedrundotcom'
+
+class SpeedrunDotComCategory < ApplicationRecord
+  belongs_to :category
+
+  def self.from_category!(category)
+    return category.srdc if category.srdc.present?
+
+    if category.game.srdc.nil?
+      srdc_game = SpeedrunDotComGame.from_game!(category.game.srdc.srdc_id).persisted?
+      return if srdc_game.nil? || !srdc_game.persisted?
+    end
+
+    result = SpeedrunDotCom::Category.from_game(category.game.srdc.srdc_id).find do |result|
+      result['name'].downcase == category.name.downcase
+    end
+    return if result.nil?
+
+    new(srdc_id: result['id'], category: category).from_result!(result)
+  end
+
+  def sync!
+    from_result!(SpeedrunDotCom::Category.from_id(srdc_id))
+  end
+
+  def from_result!(result)
+    update(
+      name:        result['name'],
+      url:         result['weblink'],
+      misc:        result['miscellaneous'],
+      rules:       result['rules'],
+      min_players: result['players']['type'] == 'up-to' ? 1 : result['players']['value'],
+      max_players: result['players']['value']
+    ) && self
+  end
+end

--- a/app/views/games/categories/_title.slim
+++ b/app/views/games/categories/_title.slim
@@ -5,8 +5,11 @@ h1 = @category.game
     - @category.game.aliases.where.not(name: @category.game.name).each do |game_alias|
       li = game_alias
 h6
-  - if @category.game.srdc.try(:url).present?
+  - if @on_game_page && @category.game.srdc.try(:url).present?
     a.btn.btn-dark.mr-2.tip href=@category.game.srdc.url title='See on Speedrun.com'
+      = image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
+  - elsif !@on_game_page && @category.srdc.try(:url).present?
+    a.btn.btn-dark.mr-2.tip href=@category.srdc.url title='See on Speedrun.com'
       = image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
   - if @category.game.srl.present?
     a.btn.btn-dark.mr-2.tip href=@category.game.srl.url title='See on SpeedRunsLive'

--- a/app/views/games/categories/show.slim
+++ b/app/views/games/categories/show.slim
@@ -6,6 +6,7 @@
     li.breadcrumb-item = link_to(@category.game, game_path(@category.game))
     - unless @on_game_page
       li.breadcrumb-item = link_to @category, game_category_path(@game, @category)
+  / Specify the full partial path because this view is used by different controllers
   = render partial: 'games/categories/title', locals: {category: @category}
 
 article data-turbolinks-temporary=true

--- a/app/views/runs/_title.slim
+++ b/app/views/runs/_title.slim
@@ -79,7 +79,7 @@ h5
               ) = icon('fas', 'question-circle')
             .row.text-light.m-2
               p Paste the link you get here:
-              = f.text_field(:video_url, class: 'form-control', placeholder: 'Paste the URL Twitch gives you here')
+              = f.text_field(:video_url, class: 'form-control', placeholder: 'Paste the URL Twitch gives you here', spellcheck: false)
           .modal-footer.bg-dark
             .float-right
               .btn-group

--- a/db/migrate/20190214221756_create_speedrun_dot_com_categories.rb
+++ b/db/migrate/20190214221756_create_speedrun_dot_com_categories.rb
@@ -1,0 +1,17 @@
+class CreateSpeedrunDotComCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :speedrun_dot_com_categories, id: :uuid do |t|
+      t.belongs_to :category, foreign_key: true, index: {unique: true}, null: false
+
+      t.string  :srdc_id,     null: false
+      t.string  :name,        null: false
+      t.string  :url,         null: false
+      t.boolean :misc,        null: false
+      t.string  :rules,       null: true
+      t.integer :min_players, null: false
+      t.integer :max_players, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_23_174102) do
+ActiveRecord::Schema.define(version: 2019_02_14_221756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -265,6 +265,20 @@ ActiveRecord::Schema.define(version: 2019_01_23_174102) do
     t.index ["srl_id"], name: "index_speed_runs_live_games_on_srl_id", unique: true
   end
 
+  create_table "speedrun_dot_com_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.string "srdc_id", null: false
+    t.string "name", null: false
+    t.string "url", null: false
+    t.boolean "misc", null: false
+    t.string "rules"
+    t.integer "min_players", null: false
+    t.integer "max_players", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_speedrun_dot_com_categories_on_category_id", unique: true
+  end
+
   create_table "speedrun_dot_com_games", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "game_id"
     t.string "srdc_id", null: false
@@ -343,6 +357,7 @@ ActiveRecord::Schema.define(version: 2019_01_23_174102) do
   add_foreign_key "segment_histories", "segments", on_delete: :cascade
   add_foreign_key "segments", "runs", on_delete: :cascade
   add_foreign_key "speed_runs_live_games", "games"
+  add_foreign_key "speedrun_dot_com_categories", "categories"
   add_foreign_key "speedrun_dot_com_games", "games"
   add_foreign_key "splits", "runs"
   add_foreign_key "twitch_users", "users"

--- a/lib/speedrundotcom.rb
+++ b/lib/speedrundotcom.rb
@@ -50,17 +50,15 @@ module SpeedrunDotCom
     def self.from_id(id)
       JSON.parse(SpeedrunDotCom.route["/games/#{CGI.escape(id)}"].get.body)['data']
     end
+  end
 
-    class << self
-      private
+  class Category
+    def self.from_game(srdc_game_id)
+      JSON.parse(SpeedrunDotCom.route["/games/#{CGI.escape(srdc_game_id)}/categories"].get.body)['data']
+    end
 
-      def get(id)
-        route(id).get
-      end
-
-      def route
-        SpeedrunDotCom.route["/games"]
-      end
+    def self.from_id(id)
+      JSON.parse(SpeedrunDotCom.route["/categories/#{CGI.escape(id)}"].get.body)['data']
     end
   end
 


### PR DESCRIPTION
Adds associations between our categories and Speedrun.com's categories, in the same way as games from #487.

Right now, this is only used to change the button on the game/category page to link to the specific Speedrun.com category. Later, after adding Speedrun.com user links, these category links will help with powering auto-submissions to Speedrun.com.