### PR TITLE
Add resize event handler to update segment graph sizes

### DIFF
--- a/app/javascript/graph_builder.js
+++ b/app/javascript/graph_builder.js
@@ -6,7 +6,7 @@ import {build_reset_graph} from "graphs/reset_graph.js"
 import {chartOptions} from "consts.js"
 import {Spinner} from 'spin.js'
 import Highcharts from 'highcharts'
-import _ from 'lodash'
+import _ from 'underscore'
 
 document.addEventListener('turbolinks:load', function() {
   if (document.getElementById('graph-holder') === null) {
@@ -101,6 +101,7 @@ document.addEventListener('click', event => {
   segChart.reflow()
 })
 
+// Use debounce to collect all resize events to fire it once instead of every single time
 window.addEventListener('resize', _.debounce(() => {
   Highcharts.charts.forEach((chart) => {
     const row = chart.renderTo.closest('tr')
@@ -108,6 +109,8 @@ window.addEventListener('resize', _.debounce(() => {
       return
     }
 
+    // Use defer to allow other JS to run on the stack in between chart sizing changes
+    // Without this the page will completely lock up for a bit while all charts are resized
     _.defer((size) => {
       chart.setSize(size)
     }, chart.container.closest('table').closest('.card').clientWidth)

--- a/app/javascript/graph_builder.js
+++ b/app/javascript/graph_builder.js
@@ -6,6 +6,7 @@ import {build_reset_graph} from "graphs/reset_graph.js"
 import {chartOptions} from "consts.js"
 import {Spinner} from 'spin.js'
 import Highcharts from 'highcharts'
+import _ from 'lodash'
 
 document.addEventListener('turbolinks:load', function() {
   if (document.getElementById('graph-holder') === null) {
@@ -99,3 +100,16 @@ document.addEventListener('click', event => {
 
   segChart.reflow()
 })
+
+window.addEventListener('resize', _.debounce(() => {
+  Highcharts.charts.forEach((chart) => {
+    const row = chart.renderTo.closest('tr')
+    if (row === null) {
+      return
+    }
+
+    _.defer((size) => {
+      chart.setSize(size)
+    }, chart.container.closest('table').closest('.card').clientWidth)
+  })
+}), 250)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -12,7 +12,6 @@ import Rails from "rails-ujs"
 import Turbolinks from "turbolinks"
 import "moment"
 import "moment-duration-format"
-import "underscore"
 import {Spinner} from "spin.js"
 import "clipboard"
 import * as Cookies from "js-cookie"
@@ -26,7 +25,6 @@ import Chartkick from "chartkick"
 window.Chartkick = Chartkick
 
 global.moment = moment
-global._ = underscore
 global.Spinner = Spinner
 global.Clipboard = clipboard
 global.Cookies = Cookies

--- a/app/javascript/upload.js
+++ b/app/javascript/upload.js
@@ -1,3 +1,5 @@
+import _ from 'underscore'
+
 const upload = function(file, options) {
   if(file === undefined) {
     document.getElementById('droplabel').textContent = 'That looks like an empty file! :('
@@ -84,8 +86,8 @@ document.addEventListener('turbolinks:load', function() {
     event.preventDefault()
     event.stopPropagation()
 
-    files = event.dataTransfer.files
-    if(files.length > 1 && gon.user === null) {
+    const files = event.dataTransfer.files
+    if (files.length > 1 && gon.user === null) {
       document.getElementById('droplabel').textContent = 'To upload more than one file at a time, please sign in.'
       return
     }
@@ -94,7 +96,7 @@ document.addEventListener('turbolinks:load', function() {
     window.isUploading = true
     window.showSpinner('#fff')
 
-    if(files.length > 1) {
+    if (files.length > 1) {
       uploadAll(_.toArray(files))
     } else {
       upload(files[0])


### PR DESCRIPTION
One thing to note is that setting the size on the graphs seems to be a pretty expensive operation.  To mitigate this a bit I did 2 things: only call `chart.setSize(...)` after not receiving anymore resize events for 250ms, and defer every call to `chart.setSize(...)` so that other things can have a chance to run off the stack.  Without the defer the page totally locks up for a few seconds, whereas with it you can at least scroll and interact with the page albeit in a very limited manner until it finishes all the resizes.  Without the debounce it makes resizing simply a nightmare with how many times it tries to resize everything even when you are still dragging the window.

The previous fix with the call to `reflow()` is still required for initial page load when the graphs are collapsed.  I did look into seeing if that was obsolete now but they seem to really be completely independent issues.

Truly fixes #504 this time.