### PR TITLE
Extract video_url from run table and create separate model

### DIFF
--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -86,11 +86,19 @@ class RunsController < ApplicationController
     end
 
     if params[@run.id36][:video_url]
-      if @run.update(video_url: params[@run.id36][:video_url])
+      if params[@run.id36][:video_url].blank?
+        @run.video.try(:destroy)
+        redirect_back(fallback_location: edit_run_path(@run), notice: 'Video deleted.')
+        return
+      end
+
+      video = Video.find_or_initialize_by(videoable: @run)
+      if video.update(url: params[@run.id36][:video_url])
         redirect_back(fallback_location: edit_run_path(@run), notice: 'Video saved! 📹')
       else
         redirect_to edit_run_path(@run), alert: @run.errors.full_messages.join(' ')
       end
+      return
     end
 
     if params[@run.id36][:archived]
@@ -117,6 +125,7 @@ class RunsController < ApplicationController
       end
     end
   end
+
   def random
     redirect_to Run.random
   end

--- a/app/dashboards/run_dashboard.rb
+++ b/app/dashboards/run_dashboard.rb
@@ -12,6 +12,7 @@ class RunDashboard < Administrate::BaseDashboard
     category: Field::BelongsTo,
     game: Field::HasOne,
     segments: Field::HasMany,
+    video: Field::BelongsTo,
     id: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -21,7 +22,6 @@ class RunDashboard < Administrate::BaseDashboard
     program: Field::String,
     claim_token: Field::Password,
     archived: Field::Boolean,
-    video_url: Field::String,
     srdc_id: Field::String,
     attempts: Field::Number,
     s3_filename: Field::String,
@@ -50,6 +50,7 @@ class RunDashboard < Administrate::BaseDashboard
     user
     game
     category
+    video
     created_at
     updated_at
     parsed_at
@@ -63,7 +64,6 @@ class RunDashboard < Administrate::BaseDashboard
     program
     claim_token
     archived
-    video_url
     attempts
     srdc_id
     s3_filename
@@ -76,10 +76,10 @@ class RunDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     user
     category
+    video
     nick
     image_url
     archived
-    video_url
     srdc_id
     attempts
     s3_filename

--- a/app/models/concerns/videoable.rb
+++ b/app/models/concerns/videoable.rb
@@ -1,0 +1,19 @@
+module Videoable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :video, as: :videoable, dependent: :destroy
+
+    def video_url
+      video.try(:url)
+    end
+
+    def twitch?
+      URI.parse(url).host.match?(/^(www\.)?twitch\.tv$/)
+    end
+
+    def youtube?
+      URI.parse(url).host.match?(/^(www\.)?(youtube\.com|youtu\.be)$/)
+    end
+  end
+end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -8,6 +8,7 @@ class Run < ApplicationRecord
   include S3Run
   include SRDCRun
   include UnparsedRun
+  include Videoable
 
   include ActionView::Helpers::DateHelper
 

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,0 +1,5 @@
+class Video < ApplicationRecord
+  belongs_to :videoable, polymorphic: true
+
+  validates_with VideoValidator
+end

--- a/app/validators/run_validator.rb
+++ b/app/validators/run_validator.rb
@@ -1,32 +1,13 @@
 class RunValidator < ActiveModel::Validator
   def validate(record)
     validate_default_timing(record)
-    validate_video_url(record)
   end
 
   private
 
   def validate_default_timing(record)
     return if %w[real game].include?(record.default_timing)
+
     record.errors[:base] << 'Default timing must be either "real" or "game".'
-  end
-
-  def validate_video_url(record)
-    record.video_url.try(:strip!)
-    if record.video_url.blank?
-      record.video_url = nil
-      return
-    end
-
-    unless valid_domain?(record.video_url)
-      record.errors[:base] << 'Your video URL must be a link to a Twitch or YouTube video.'
-    end
-  rescue URI::InvalidURIError
-    record.errors[:base] << 'Your video URL must be a link to a Twitch or YouTube video.'
-  end
-
-  def valid_domain?(url)
-    uri = URI.parse(url)
-    uri.host.present? && uri.host.match?(/^(www\.)?(twitch\.tv|youtube\.com|youtu\.be)$/)
   end
 end

--- a/app/validators/video_validator.rb
+++ b/app/validators/video_validator.rb
@@ -1,0 +1,21 @@
+class VideoValidator < ActiveModel::Validator
+  def validate(record)
+    validate_url(record)
+  end
+
+  private
+
+  ERROR_MSG = 'Your video URL must be a link to a Twitch or YouTube video.'.freeze
+
+  def validate_url(record)
+    record.url.try(:strip!)
+    record.errors[:base] << ERROR_MSG unless valid_domain?(record.url)
+  rescue URI::InvalidURIError
+    record.errors[:base] << ERROR_MSG
+  end
+
+  def valid_domain?(url)
+    uri = URI.parse(url)
+    uri.host.present? && uri.host.match?(/^(www\.)?(twitch\.tv|youtube\.com|youtu\.be)$/)
+  end
+end

--- a/app/views/runs/_timeline.slim
+++ b/app/views/runs/_timeline.slim
@@ -6,10 +6,10 @@
   .timeline-background.mt-3
     .timeline.shadow
       - run.collapsed_segments(timing).each.with_index do |segment, index|
-        .pure-u.split id="#{run.id36}-split-#{index}" data={start_ms: segment.start(timing).to_ms} class=next_timeline_color(run.id36) style="width: #{segment.duration_ms(timing).to_f / scale_to * 100}%; z-index: #{index}; #{'cursor: pointer;' if run.video_url.present?}"
+        .pure-u.split id="#{run.id36}-split-#{index}" data={start_ms: segment.start(timing).to_ms} class=next_timeline_color(run.id36) style="width: #{segment.duration_ms(timing).to_f / scale_to * 100}%; z-index: #{index}; #{'cursor: pointer;' if run.video.present?}"
           .p-2
             .text-light = segment.name.presence || '-'
             .text-light-50 = format_ms(segment.duration_ms(timing), precise: run.short?(timing))
-  - if run.video_url.present? && URI.parse(run.video_url).host.match?(/^(www\.)?twitch\.tv$/)
+  - if run.video.try(:twitch?)
     div
       span#timeline-video-progress: span#timeline-video-caret = icon('fas', 'caret-up')

--- a/app/views/runs/_title.slim
+++ b/app/views/runs/_title.slim
@@ -10,12 +10,10 @@ h5
   - if run.srdc_id.present?
     a.badge.badge-dark.tip title='See on Speedrun.com' href=run.srdc_url
       = image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
-  - if run.video_url.present?
-    - uri = URI.parse(run.video_url)
-    - if uri.host.match?(/^(www\.)?(youtube\.com|youtu\.be)$/)
-      a.badge.badge-dark.tip href=run.video_url title='Watch on YouTube' => icon('fab', 'youtube')
-    - elsif !uri.host.match?(/^(www\.)?(twitch\.tv)$/)
-      a.badge.badge-dark.tip href=run.video_url title='Watch video' => icon('fas', 'video')
+  - if run.video.try(:youtube?)
+    a.badge.badge-dark.tip href=run.video.url title='Watch on YouTube' => icon('fab', 'youtube')
+  - elsif  run.video.present? && !run.video.try(:twitch?)
+    a.badge.badge-dark.tip href=run.video.url title='Watch video' => icon('fas', 'video')
 
 .btn-toolbar role='toolbar' aria={label: 'Run navigation'}
   .btn-group.m-2 role='group' aria={label: 'Run navigation'}
@@ -46,7 +44,7 @@ h5
         - else
           button.btn.btn-outline-secondary disabled=true Sign In to Claim
   .btn-group.m-2 role='group' aria={label: 'Calls to action'}
-    - if run.belongs_to?(current_user) && run.video_url.nil? && run.highlight_suggestion.present?
+    - if run.belongs_to?(current_user) && run.video.nil? && run.highlight_suggestion.present?
       a.btn.btn-twitch.tip-top(
         href='#'
         data={toggle: :modal, target: '#highlight'}
@@ -54,7 +52,7 @@ h5
       )
         => icon('fab', 'twitch')
         span Auto-Highlight Possible
-- if run.belongs_to?(current_user) && run.video_url.nil? && run.highlight_suggestion.present?
+- if run.belongs_to?(current_user) && run.video.nil? && run.highlight_suggestion.present?
   #highlight.modal.fade tabindex='-1' role='dialog' aria={labelledby: 'highlight-label', hidden: true}
     .modal-dialog role='document'
       .modal-content

--- a/app/views/runs/show.slim
+++ b/app/views/runs/show.slim
@@ -19,7 +19,7 @@
 
 .row.mx-1
   .col-md-6
-    - if @run.video_url.present? && URI.parse(@run.video_url).host.match?(/^(www\.)?(twitch\.tv)$/)
+    - if @run.video.try(:twitch?)
         .card.my-3 style='padding-bottom: 56.25%'
           #twitch-player style='position: absolute; top: 0; right: 0; bottom: 0; left: 0'
     = render partial: 'runs/split_table', locals: {\

--- a/db/migrate/20190219094039_create_videos.rb
+++ b/db/migrate/20190219094039_create_videos.rb
@@ -1,0 +1,25 @@
+class CreateVideos < ActiveRecord::Migration[5.2]
+  def up
+    create_table :videos, id: :uuid do |t|
+      t.string :url, null: false
+      t.references :videoable, polymorphic: true, index: true
+      t.timestamps
+    end
+
+    Run.where.not(video_url: nil).each do |r|
+      Video.create!(videoable: r, url: r.video_url)
+    end
+
+    safety_assured { remove_column :runs, :video_url }
+  end
+
+  def down
+    add_column :runs, :video_url, :string
+
+    Video.find_each do |v|
+      v.videoable.update(video_url: v.url)
+    end
+
+    drop_table :videos
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_14_221756) do
+ActiveRecord::Schema.define(version: 2019_02_19_094039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -202,7 +202,6 @@ ActiveRecord::Schema.define(version: 2019_02_14_221756) do
     t.string "program"
     t.string "claim_token"
     t.boolean "archived", default: false, null: false
-    t.string "video_url"
     t.string "srdc_id"
     t.integer "attempts"
     t.string "s3_filename", null: false
@@ -345,6 +344,15 @@ ActiveRecord::Schema.define(version: 2019_02_14_221756) do
     t.datetime "updated_at"
     t.citext "name"
     t.index ["name"], name: "index_users_on_name", unique: true
+  end
+
+  create_table "videos", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "url", null: false
+    t.string "videoable_type"
+    t.bigint "videoable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["videoable_type", "videoable_id"], name: "index_videos_on_videoable_type_and_videoable_id"
   end
 
   add_foreign_key "game_aliases", "games", on_delete: :cascade

--- a/spec/controllers/runs_controller_spec.rb
+++ b/spec/controllers/runs_controller_spec.rb
@@ -117,7 +117,8 @@ describe RunsController do
   end
 
   describe '#update' do
-    context 'category' do
+    context 'for an unowned run without permissions' do
+      let(:run) { FactoryBot.create(:run, :unowned) }
       let(:response) do
         put(
           :update, params: {
@@ -127,58 +128,295 @@ describe RunsController do
         )
       end
 
-      context 'for an unowned run' do
-        let(:run) { FactoryBot.create(:run, :unowned) }
+      context 'for a logged-out user' do
+        before { allow(controller).to receive(:current_user).and_return(nil) }
 
-        context 'by a logged-in user' do
-          before { allow(controller).to receive(:current_user).and_return(FactoryBot.build(:user)) }
-
-          it 'returns a 403' do
-            expect(response).to have_http_status(403)
-          end
+        it 'returns a 403' do
+          expect(response).to have_http_status(403)
         end
+      end
 
-        context 'by a logged-out user' do
+      context 'for a logged-in user' do
+        before { allow(controller).to receive(:current_user).and_return(FactoryBot.build(:user)) }
+
+        it 'returns a 403' do
+          expect(response).to have_http_status(403)
+        end
+      end
+    end
+
+    context 'for an owned run without permissions' do
+      let(:run) { FactoryBot.create(:run, :owned) }
+      let(:response) do
+        put(
+          :update, params: {
+            'run' => run.id36,
+            "#{run.id36}[category]" => FactoryBot.create(:category).id
+          }
+        )
+      end
+
+      context "by a user who doesn't own the run" do
+        context "because they're not logged in" do
           before { allow(controller).to receive(:current_user).and_return(nil) }
 
           it 'returns a 403' do
             expect(response).to have_http_status(403)
           end
         end
-      end
 
-      context 'for an owned run' do
-        let(:run) { FactoryBot.create(:run, :owned) }
+        context "because they're a different user" do
+          before { allow(controller).to receive(:current_user).and_return(FactoryBot.build(:user)) }
 
-        context "by a user who doesn't own the run" do
-          context "because they're not logged in" do
-            before { allow(controller).to receive(:current_user).and_return(nil) }
-
-            it 'returns a 403' do
-              expect(response).to have_http_status(403)
-            end
-          end
-
-          context "because they're a different user" do
-            before { allow(controller).to receive(:current_user).and_return(FactoryBot.build(:user)) }
-
-            it 'returns a 403' do
-              expect(response).to have_http_status(403)
-            end
+          it 'returns a 403' do
+            expect(response).to have_http_status(403)
           end
         end
+      end
+    end
 
-        context 'by the user who owns the run' do
-          before { allow(controller).to receive(:current_user).and_return(run.user) }
-          before { allow(Twitch::Videos).to receive(:recent).and_return([]) }
+    context 'changing categories by the owner' do
+      let(:run) { FactoryBot.create(:run, :owned) }
+      let(:category) { FactoryBot.create(:category) }
+      let(:response) do
+        put(
+          :update, params: {
+            'run' => run.id36,
+            "#{run.id36}[category]" => category.id
+          }
+        )
+      end
+      before { allow(controller).to receive(:current_user).and_return(run.user) }
+      before { allow(Twitch::Videos).to receive(:recent).and_return([]) }
 
-          it 'returns a 302' do
-            expect(response).to have_http_status(302)
-          end
+      it 'returns a 302' do
+        expect(response).to have_http_status(302)
+      end
 
-          it 'redirects to the run edit page' do
-            expect(response).to redirect_to(edit_run_path(run))
-          end
+      it 'redirects to the run edit page' do
+        expect(response).to redirect_to(edit_run_path(run))
+      end
+
+      it 'has the new category id' do
+        response
+        expect(run.reload.category).to eq(category)
+      end
+    end
+
+    context 'disowning the run by the owner' do
+      let(:run) { FactoryBot.create(:run, :owned) }
+      let(:response) do
+        put(
+          :update, params: {
+            'run' => run.id36,
+            "#{run.id36}[disown]" => true
+          }
+        )
+      end
+      before { allow(controller).to receive(:current_user).and_return(run.user) }
+      before { allow(Twitch::Videos).to receive(:recent).and_return([]) }
+
+      it 'returns a 302' do
+        expect(response).to have_http_status(302)
+      end
+
+      it 'redirects to the run edit page' do
+        expect(response).to redirect_to(run_path(run))
+      end
+
+      it 'has no owner' do
+        response
+        expect(run.reload.user).to be_nil
+      end
+    end
+
+    context 'changing srdc urls by the owner' do
+      let(:run) { FactoryBot.create(:run, :owned) }
+      let(:response) do
+        put(
+          :update, params: {
+            'run' => run.id36,
+            "#{run.id36}[srdc_url]" => 'https://www.speedrun.com/tfoc/run/6yjoqgzd'
+          }
+        )
+      end
+      before { allow(controller).to receive(:current_user).and_return(run.user) }
+      before { allow(Twitch::Videos).to receive(:recent).and_return([]) }
+
+      it 'returns a 302' do
+        expect(response).to have_http_status(302)
+      end
+
+      it 'redirects to the run edit page' do
+        expect(response).to redirect_to(edit_run_path(run))
+      end
+
+      it 'has the new srdc id' do
+        response
+        expect(run.reload.srdc_id).to eq('6yjoqgzd')
+      end
+    end
+
+    context 'changing video urls by the owner' do
+      let(:run) { FactoryBot.create(:run, :owned) }
+      before { allow(controller).to receive(:current_user).and_return(run.user) }
+      before { allow(Twitch::Videos).to receive(:recent).and_return([]) }
+
+      context 'adding a new url' do
+        let(:response) do
+          put(
+            :update, params: {
+              'run' => run.id36,
+              "#{run.id36}[video_url]" => 'http://www.twitch.tv/glacials/c/3463112'
+            }
+          )
+        end
+
+        it 'returns a 302' do
+          expect(response).to have_http_status(302)
+        end
+
+        it 'redirects to the run edit page' do
+          expect(response).to redirect_to(edit_run_path(run))
+        end
+
+        it 'has the new video url' do
+          response
+          expect(run.reload.video.url).to eq('http://www.twitch.tv/glacials/c/3463112')
+        end
+      end
+
+      context 'removing the video' do
+        let(:response) do
+          put(
+            :update, params: {
+              'run' => run.id36,
+              "#{run.id36}[video_url]" => ''
+            }
+          )
+        end
+
+        it 'returns a 302' do
+          expect(response).to have_http_status(302)
+        end
+
+        it 'redirects to the run edit page' do
+          expect(response).to redirect_to(edit_run_path(run))
+        end
+
+        it 'has the new video url' do
+          FactoryBot.create(:video, videoable: run)
+          response
+          expect(run.reload.video).to be_nil
+        end
+      end
+    end
+
+    context 'archiving by the owner' do
+      before { allow(controller).to receive(:current_user).and_return(run.user) }
+      before { allow(Twitch::Videos).to receive(:recent).and_return([]) }
+
+      context 'from unarchived to archived' do
+        let(:run) { FactoryBot.create(:run, :owned) }
+        let(:response) do
+          put(
+            :update, params: {
+              'run' => run.id36,
+              "#{run.id36}[archived]" => true
+            }
+          )
+        end
+
+        it 'returns a 302' do
+          expect(response).to have_http_status(302)
+        end
+
+        it 'redirects to the run edit page' do
+          expect(response).to redirect_to(edit_run_path(run))
+        end
+
+        it 'has been archived' do
+          response
+          expect(run.reload.archived).to eq(true)
+        end
+      end
+
+      context 'from archived to unarchived' do
+        let(:run) { FactoryBot.create(:run, :owned, :archived) }
+        let(:response) do
+          put(
+            :update, params: {
+              'run' => run.id36,
+              "#{run.id36}[archived]" => false
+            }
+          )
+        end
+        it 'returns a 302' do
+          expect(response).to have_http_status(302)
+        end
+
+        it 'redirects to the run edit page' do
+          expect(response).to redirect_to(edit_run_path(run))
+        end
+
+        it 'has been unarchived' do
+          response
+          expect(run.reload.archived).to eq(false)
+        end
+      end
+    end
+
+    context 'changing the default timing' do
+      before { allow(controller).to receive(:current_user).and_return(run.user) }
+      before { allow(Twitch::Videos).to receive(:recent).and_return([]) }
+
+      context 'to gametime' do
+        let(:run) { FactoryBot.create(:run, :owned) }
+        let(:response) do
+          put(
+            :update, params: {
+              'run' => run.id36,
+              "#{run.id36}[default_timing]" => 'game'
+            }
+          )
+        end
+
+        it 'returns a 302' do
+          expect(response).to have_http_status(302)
+        end
+
+        it 'redirects to the run edit page' do
+          expect(response).to redirect_to(edit_run_path(run))
+        end
+
+        it 'has the new timing' do
+          response
+          expect(run.reload.default_timing).to eq('game')
+        end
+      end
+
+      context 'to realtime' do
+        let(:run) { FactoryBot.create(:run, :owned, default_timing: Run::GAME) }
+        let(:response) do
+          put(
+            :update, params: {
+              'run' => run.id36,
+              "#{run.id36}[default_timing]" => 'real'
+            }
+          )
+        end
+
+        it 'returns a 302' do
+          expect(response).to have_http_status(302)
+        end
+
+        it 'redirects to the run edit page' do
+          expect(response).to redirect_to(edit_run_path(run))
+        end
+
+        it 'has the new timing' do
+          response
+          expect(run.reload.default_timing).to eq('real')
         end
       end
     end

--- a/spec/factories/run_factory.rb
+++ b/spec/factories/run_factory.rb
@@ -34,7 +34,6 @@ FactoryBot.define do
   factory :run do
     category
 
-    video_url   { 'http://www.twitch.tv/glacials/c/3463112' }
     s3_filename { test_files[:livesplit14][:s3_filename] }
 
     trait :owned do
@@ -43,6 +42,10 @@ FactoryBot.define do
 
     trait :unowned do
       user { nil }
+    end
+
+    trait :archived do
+      archived { true }
     end
 
     trait :nicked do

--- a/spec/factories/video_factory.rb
+++ b/spec/factories/video_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :video do
+    for_run
+
+    url { 'http://www.twitch.tv/glacials/c/3463112' }
+
+    trait :for_run do
+      association(:videoable, factory: :run)
+    end
+  end
+end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -77,24 +77,6 @@ describe Run, type: :model do
     end
   end
 
-  context 'with a valid video URL to a non-valid location' do
-    let(:run) { FactoryBot.build(:run, video_url: 'http://google.com/') }
-
-    it 'fails to validate' do
-      expect(run).not_to be_valid
-    end
-  end
-
-  context 'with an invalid video URL' do
-    let(:run) do
-      FactoryBot.build(:run, video_url: 'Huge improvement. That King Boo fight tho... :/ 4 HP strats!')
-    end
-
-    it 'fails to validate' do
-      expect(run).not_to be_valid
-    end
-  end
-
   context 'just created' do
     it 'has a non-nil claim token' do
       expect(run.claim_token).not_to be_nil

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe Video, type: :model do
+  context 'with a valid video URL' do
+    let(:video) { FactoryBot.build(:video) }
+
+    it 'successfully validates' do
+      expect(video).to be_valid
+    end
+  end
+
+  context 'with a valid video URL to a non-valid location' do
+    let(:video) { FactoryBot.build(:video, url: 'http://google.com/') }
+
+    it 'fails to validate' do
+      expect(video).not_to be_valid
+    end
+  end
+
+  context 'with an invalid video URL' do
+    let(:video) do
+      FactoryBot.build(:video, url: 'Huge improvement. That King Boo fight tho... :/ 4 HP strats!')
+    end
+
+    it 'fails to validate' do
+      expect(video).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
This change will allow us to have videos attached to other models, like games/categories, going forward.

Much of this PR is adding tests for all the branches of `runs_controller#update`.  I noticed when I was adding to it that an error that was being thrown accidentally wasn't being picked up by the tests, so I took a look and noticed none of the branches besides category swapping was tested.  So I went ahead and added tests for most of the branches (mostly missing error updating the various fields) in order to make sure that futures changes would have a higher chance of picking up errors.

For the `safety_assured` call in the migration, I'm not really sure what is was trying to tell me to do, so in order to test it I just added it.  I noticed one of them before in a commit but didn't really understand it.