### PR TITLE
Add Speedrun.com user links

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,10 @@ Documentation:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
+Layout/AlignHash:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle:      table
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/app/assets/stylesheets/brands.sass
+++ b/app/assets/stylesheets/brands.sass
@@ -7,6 +7,10 @@ $twitch-faded: rgba(100, 65, 164, 0.8)
 $patreon:       rgba(230, 70, 26, 1)
 $patreon-faded: rgba(230, 70, 26, 0.8)
 
+$srdc:       rgba(120, 89, 36, 1)
+$srdc-faded: rgba(120, 89, 36, 0.8)
+
+
 .text-twitch
   color: $twitch !important
 
@@ -80,4 +84,29 @@ $patreon-faded: rgba(230, 70, 26, 0.8)
 
 .btn-outline-patreon:hover
   background: $patreon !important
+  color: rgba(255, 255, 255, 0.8) !important
+
+.text-srdc
+  color: $srdc !important
+
+.bg-srdc
+  background: $srdc !important
+
+.border-srdc
+  border-color: $srdc !important
+
+.btn-srdc
+  background: $srdc !important
+  color: rgba(255, 255, 255, 0.8)
+
+.btn-srdc:hover
+  background: $srdc-faded !important
+  color: rgba(255, 255, 255, 1)
+
+.btn-outline-srdc
+  border-color: $srdc !important
+  color: $srdc !important
+
+.btn-outline-srdc:hover
+  background: $srdc !important
   color: rgba(255, 255, 255, 0.8) !important

--- a/app/controllers/runs/application_controller.rb
+++ b/app/controllers/runs/application_controller.rb
@@ -2,21 +2,25 @@ class Runs::ApplicationController < ApplicationController
   private
 
   def set_run
-    @run = Run.includes(:user, :game, :category, :segments).find_by(id: params[:run].to_i(36)) || Run.find_by!(nick: params[:run])
+    @run = Run.includes(:user, :game, :category, :segments).find_by(id: params[:run].to_i(36))
     timing = params[:timing] || @run.default_timing
     gon.run = {id: @run.id36, splits: @run.collapsed_segments(timing)}
     gon.scale_to = @run.duration_ms(timing)
 
     if params[:blank] == '1' # Build a fake, non-persisted run
-      fake_run = Run.new(category: @run.category, program: ExchangeFormat.to_sym)
-      @run.segments.find_each do |segment|
-        fake_run.segments << Segment.new(segment_number: segment.segment_number, name: segment.name)
-      end
-
-      @run = fake_run
+      set_blank_run
       return
     end
   rescue ActionController::UnknownFormat, ActiveRecord::RecordNotFound
     not_found
+  end
+
+  def set_blank_run
+    fake_run = Run.new(category: @run.category, program: ExchangeFormat.to_sym)
+    @run.segments.find_each do |segment|
+      fake_run.segments << Segment.new(segment_number: segment.segment_number, name: segment.name)
+    end
+
+    @run = fake_run
   end
 end

--- a/app/controllers/speedrun_dot_com_users_controller.rb
+++ b/app/controllers/speedrun_dot_com_users_controller.rb
@@ -1,22 +1,34 @@
 class SpeedrunDotComUsersController < ApplicationController
   def create
+    if cannot?(:create, SpeedrunDotComUser)
+      unauthorized
+      return
+    end
+
     if SpeedrunDotComUser.from_api_key!(params[:speedrun_dot_com_user][:api_key].strip, user: current_user)
-      if URI(request.referer).path == settings_path
-        redirect_back(fallback_location: settings_path, notice: 'Speedrun.com account linked! 🏆')
-        return
-      end
-      redirect_to("#{URI(request.referer).path}?srdc_submit=1")
+      redirect
       return
     end
 
     redirect_back(
       fallback_location: settings_path,
-      alert: "Couldn't link to Speedrun.com. Did you enter your API key correctly?"
+      alert:             "Couldn't link to Speedrun.com. Did you enter your API key correctly?"
     )
   end
 
   def destroy
     current_user.srdc.try(:destroy)
     redirect_back fallback_location: settings_path, notice: 'Speedrun.com account unlinked! 🚫🏆'
+  end
+
+  private
+
+  def redirect
+    if URI(request.referer).path == settings_path
+      redirect_back(fallback_location: settings_path, notice: 'Speedrun.com account linked! 🏆')
+      return
+    end
+
+    redirect_to("#{URI(request.referer).path}?srdc_submit=1")
   end
 end

--- a/app/controllers/speedrun_dot_com_users_controller.rb
+++ b/app/controllers/speedrun_dot_com_users_controller.rb
@@ -1,0 +1,22 @@
+class SpeedrunDotComUsersController < ApplicationController
+  def create
+    if SpeedrunDotComUser.from_api_key!(params[:speedrun_dot_com_user][:api_key].strip, user: current_user)
+      if URI(request.referer).path == settings_path
+        redirect_back(fallback_location: settings_path, notice: 'Speedrun.com account linked! 🏆')
+        return
+      end
+      redirect_to("#{URI(request.referer).path}?srdc_submit=1")
+      return
+    end
+
+    redirect_back(
+      fallback_location: settings_path,
+      alert: "Couldn't link to Speedrun.com. Did you enter your API key correctly?"
+    )
+  end
+
+  def destroy
+    current_user.srdc.try(:destroy)
+    redirect_back fallback_location: settings_path, notice: 'Speedrun.com account unlinked! 🚫🏆'
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,6 +21,7 @@ class Ability
     can(%i[create read update destroy], Rivalry,                 from_user_id: user.id)
     can(%i[create read update destroy], Doorkeeper::Application, owner_id:     user.id)
     can(%i[create read update destroy], RunLike,                 user_id:      user.id)
+    can(%i[create read update destroy], SpeedrunDotComUser,      user_id:      user.id)
 
     cannot(%i[update destroy], Run, user_id: nil)
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -51,11 +51,7 @@ class Category < ApplicationRecord
   end
 
   def sync_with_srdc
-    if srdc.nil?
-      SpeedrunDotComCategory.from_category!(self)
-      return
-    end
-
+    return SpeedrunDotComCategory.from_category!(self) if srdc.nil?
     srdc.sync!
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,8 +1,10 @@
 class Category < ApplicationRecord
   belongs_to :game
-  has_many :runs
-  has_many :users, through: :runs
+
+  has_many :runs,      dependent: :nullify
   has_many :rivalries, dependent: :destroy
+
+  has_many :users, through: :runs
 
   has_one :srdc, class_name: 'SpeedrunDotComCategory', dependent: :destroy
 
@@ -10,21 +12,23 @@ class Category < ApplicationRecord
 
   def self.global_aliases
     {
-      'Any% (NG+)' => 'Any% NG+',
-      'Any% (New Game+)' => 'Any% NG+',
-      'Any %' => 'Any%',
+      'Any% (NG+)'        => 'Any% NG+',
+      'Any% (New Game+)'  => 'Any% NG+',
+      'Any %'             => 'Any%',
       'All Skills No OOB' => 'All Skills no OOB no TA' # for ori_de
     }
   end
 
   def self.from_name(name)
     return nil if name.blank?
+
     name = name.strip
-    where('lower(name) = lower(?)', name).first
+    find_by('lower(name) = lower(?)', name)
   end
 
   def self.from_name!(name)
     return nil if name.blank?
+
     name = name.strip
     where('lower(name) = lower(?)', name).first_or_create(name: name)
   end
@@ -52,6 +56,7 @@ class Category < ApplicationRecord
 
   def sync_with_srdc
     return SpeedrunDotComCategory.from_category!(self) if srdc.nil?
+
     srdc.sync!
   end
 
@@ -74,6 +79,7 @@ class Category < ApplicationRecord
   # category. Does nothing if the given category is nil.
   def merge_into!(category)
     return if category.nil?
+
     ApplicationRecord.transaction do
       runs.update_all(category_id: category.id)
       rivalries.update_all(category_id: category.id)

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -9,9 +9,9 @@ class Game < ApplicationRecord
 
   has_many :categories, dependent: :destroy
   has_many :runs, through: :categories
-  has_many :users, -> { distinct }, through: :runs
+  has_many :users,   -> { distinct }, through: :runs
   has_many :runners, -> { distinct }, through: :runs, class_name: 'User'
-  has_many :aliases, class_name: 'GameAlias'
+  has_many :aliases, class_name: 'GameAlias', dependent: :destroy
 
   has_one :srdc, class_name: 'SpeedrunDotComGame', dependent: :destroy
   has_one :srl,  class_name: 'SpeedRunsLiveGame',  dependent: :destroy
@@ -31,12 +31,14 @@ class Game < ApplicationRecord
   def self.from_name(name)
     name = name.strip
     return nil if name.blank?
-    joins(:aliases).where(game_aliases: {name: name}).first
+
+    joins(:aliases).find_by(game_aliases: {name: name})
   end
 
   def self.from_name!(name)
     name = name.strip
     return nil if name.blank?
+
     joins(:aliases).where(game_aliases: {name: name}).first_or_create(name: name)
   end
 
@@ -46,11 +48,13 @@ class Game < ApplicationRecord
 
   def sync_with_srdc
     return SpeedrunDotComGame.from_game!(self) if srdc.nil?
+
     srdc.sync!
   end
 
   def sync_with_srl
     return SpeedRunsLiveGame.from_game!(self) if srl.nil?
+
     srl.sync!
   end
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -45,20 +45,12 @@ class Game < ApplicationRecord
   end
 
   def sync_with_srdc
-    if srdc.nil?
-      SpeedrunDotComGame.from_game!(self)
-      return
-    end
-
+    return SpeedrunDotComGame.from_game!(self) if srdc.nil?
     srdc.sync!
   end
 
   def sync_with_srl
-    if srl.nil?
-      SpeedRunsLiveGame.from_game!(self)
-      return
-    end
-
+    return SpeedRunsLiveGame.from_game!(self) if srl.nil?
     srl.sync!
   end
 

--- a/app/models/speedrun_dot_com_user.rb
+++ b/app/models/speedrun_dot_com_user.rb
@@ -4,7 +4,7 @@ class SpeedrunDotComUser < ApplicationRecord
   belongs_to :user
 
   def self.from_api_key!(api_key, user:)
-    srdc_user = SpeedrunDotComUser.find_by(api_key: api_key)
+    srdc_user = find_by(api_key: api_key)
     return srdc_user if srdc_user.present?
 
     result = SpeedrunDotCom::User.from_api_key(api_key)
@@ -19,8 +19,8 @@ class SpeedrunDotComUser < ApplicationRecord
 
   def from_result!(result)
     update(
-      name:           result['names']['international'],
-      url:            result['weblink'],
+      name: result['names']['international'],
+      url:  result['weblink']
     ) && self
   end
 end

--- a/app/models/speedrun_dot_com_user.rb
+++ b/app/models/speedrun_dot_com_user.rb
@@ -1,0 +1,26 @@
+require 'speedrundotcom'
+
+class SpeedrunDotComUser < ApplicationRecord
+  belongs_to :user
+
+  def self.from_api_key!(api_key, user:)
+    srdc_user = SpeedrunDotComUser.find_by(api_key: api_key)
+    return srdc_user if srdc_user.present?
+
+    result = SpeedrunDotCom::User.from_api_key(api_key)
+    return if result.nil?
+
+    new(srdc_id: result['id'], api_key: api_key, user: user).from_result!(result)
+  end
+
+  def sync!
+    from_result!(SpeedrunDotCom::User.from_id(srdc_id))
+  end
+
+  def from_result!(result)
+    update(
+      name:           result['names']['international'],
+      url:            result['weblink'],
+    ) && self
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,17 +4,19 @@ class User < ApplicationRecord
   include RivalUser
   include RunnerUser
 
-  has_many :runs
+  has_many :runs, dependent: :nullify
   has_many :categories, -> { distinct }, through: :runs
   has_many :games,      -> { distinct }, through: :runs
 
-  has_many :run_likes
+  has_many :run_likes, dependent: :destroy
 
-  has_many :rivalries,          foreign_key: :from_user_id, dependent: :destroy
-  has_many :incoming_rivalries, foreign_key: :to_user_id,   dependent: :destroy, class_name: 'Rivalry'
+  has_many :rivalries,          foreign_key: :from_user_id, dependent: :destroy, inverse_of: 'from_user'
+  has_many :incoming_rivalries, foreign_key: :to_user_id,   dependent: :destroy, inverse_of: 'to_user',
+                                class_name: 'Rivalry'
 
-  has_many :twitch_user_follows,   foreign_key: :from_user_id, dependent: :destroy
-  has_many :twitch_user_followers, foreign_key: :to_user_id,   dependent: :destroy, class_name: 'TwitchUserFollow'
+  has_many :twitch_user_follows,   foreign_key: :from_user_id, dependent: :destroy, inverse_of: 'from_user'
+  has_many :twitch_user_followers, foreign_key: :to_user_id,   dependent: :destroy, inverse_of: 'to_user',
+                                   class_name: 'TwitchUserFollow'
 
   has_many :twitch_follows,   through: :twitch_user_follows,   source: :to_user
   has_many :twitch_followers, through: :twitch_user_followers, source: :from_user
@@ -24,13 +26,10 @@ class User < ApplicationRecord
   has_one :google,  dependent: :destroy, class_name: 'GoogleUser'
   has_one :srdc,    dependent: :destroy, class_name: 'SpeedrunDotComUser'
 
-  has_many :applications,  class_name: 'Doorkeeper::Application', foreign_key: :owner_id
-  has_many :access_grants, class_name: 'Doorkeeper::AccessGrant', foreign_key: :resource_owner_id
-  has_many :access_tokens, class_name: 'Doorkeeper::AccessToken', foreign_key: :resource_owner_id
-
-  after_destroy do |user|
-    user.runs.update_all(user_id: nil)
-  end
+  has_many :applications,  class_name: 'Doorkeeper::Application', dependent: :destroy, foreign_key: :owner_id,
+                           inverse_of: 'owner'
+  has_many :access_grants, class_name: 'Doorkeeper::AccessGrant', dependent: :destroy, foreign_key: :resource_owner_id
+  has_many :access_tokens, class_name: 'Doorkeeper::AccessToken', dependent: :destroy, foreign_key: :resource_owner_id
 
   NAME_REGEX = /\A[A-Za-z0-9_]+\z/.freeze
 
@@ -43,6 +42,7 @@ class User < ApplicationRecord
   def self.search(term)
     term = term.strip
     return nil if term.blank?
+
     search_for_name(term)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,9 +19,10 @@ class User < ApplicationRecord
   has_many :twitch_follows,   through: :twitch_user_follows,   source: :to_user
   has_many :twitch_followers, through: :twitch_user_followers, source: :from_user
 
-  has_one  :patreon, class_name: 'PatreonUser', dependent: :destroy
-  has_one  :twitch,  class_name: 'TwitchUser',  dependent: :destroy
-  has_one  :google,  class_name: 'GoogleUser',  dependent: :destroy
+  has_one :patreon, dependent: :destroy, class_name: 'PatreonUser'
+  has_one :twitch,  dependent: :destroy, class_name: 'TwitchUser'
+  has_one :google,  dependent: :destroy, class_name: 'GoogleUser'
+  has_one :srdc,    dependent: :destroy, class_name: 'SpeedrunDotComUser'
 
   has_many :applications,  class_name: 'Doorkeeper::Application', foreign_key: :owner_id
   has_many :access_grants, class_name: 'Doorkeeper::AccessGrant', foreign_key: :resource_owner_id

--- a/app/views/settings/_account_links.slim
+++ b/app/views/settings/_account_links.slim
@@ -1,9 +1,9 @@
-.card-deck.mb-3
+.card-columns.mb-3 style='column-count: 2'
   - if current_user.twitch.nil?
     .card.border-twitch
       .card-body.text-light
         span> ✗ Not linked with Twitch
-      .card-footer
+      .card-footer.clearfix
         .float-right
           a.btn.btn-twitch href='/auth/twitch' Link with Twitch
   - else
@@ -11,7 +11,7 @@
       .card-body.text-light
         span ✓ Linked with Twitch as
         b< = current_user.twitch.display_name
-      .card-footer
+      .card-footer.clearfix
         .float-right
           - if current_user.google.present?
             a.btn.btn-outline-light href='/auth/twitch/unlink' Unlink
@@ -24,7 +24,7 @@
     .card.border-google
       .card-body
         span> ✗ Not linked with Google
-      .card-footer
+      .card-footer.clearfix
         .float-right
           a.btn.btn-google href='/auth/google'
             => icon('fab', 'google')
@@ -34,7 +34,7 @@
       .card-body.text-light
         span ✓ Linked with Google as
         b< = current_user.google.name
-      .card-footer
+      .card-footer.clearfix
         .float-right
           - if current_user.twitch.present?
             a.btn.btn-outline-light href='/auth/google/unlink' Unlink
@@ -47,7 +47,7 @@
     .card.border-patreon
       .card-body
         span> ✗ Not linked with Patreon
-      .card-footer
+      .card-footer.clearfix
         .float-right
           a.btn.btn-patreon.mr-2 href='/auth/patreon'
             => icon('fab', 'patreon')
@@ -58,7 +58,26 @@
       .card-body.text-light
         span ✓ Linked with Patreon as
         b< = current_user.patreon.full_name
-      .card-footer
+      .card-footer.clearfix
         .float-right
           a.btn.btn-outline-light.mr-2 href='/auth/patreon/unlink' Unlink
           a.btn.btn-light href=patreon_url Visit
+  - if current_user.srdc.nil?
+    .card.border-srdc
+      .card-body
+        span> ✗ Not linked with Speedrun.com
+      .card-footer.clearfix
+        .float-right
+          a.btn.btn-srdc.mr-2 href='#' data={toggle: :modal, target: '#srdc-link'}
+            => image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
+            ' Link with Speedrun.com
+    = render partial: 'shared/srdc_link_modal'
+  - else
+    .card.bg-srdc
+      .card-body.text-light
+        span ✓ Linked with Speedrun.com as
+        b< = current_user.srdc.name
+      .card-footer.clearfix
+        .float-right
+          = button_to speedrun_dot_com_user_path, method: :delete, class: 'btn btn-outline-light mr-2'
+            ' Unlink

--- a/app/views/shared/_srdc_link_modal.slim
+++ b/app/views/shared/_srdc_link_modal.slim
@@ -1,0 +1,25 @@
+#srdc-link.modal.fade tabindex='-1' role='dialog' aria={labelledby: 'srdc-label', hidden: true}
+  .modal-dialog role='document'
+    .modal-content
+      = form_for SpeedrunDotComUser.new do |f|
+        .modal-header.bg-primary
+          h5.text-light Auto-Submit
+        .modal-body.bg-dark
+          .row.text-light.m-2
+            p
+              ' In the future, Splits I/O will be able to submit runs to Speedrun.com for you automatically. To get
+              ' ahead of the curve, you can choose to link up your Speedrun.com account now.
+            p Splits I/O will never take action on your Speedrun.com account without your permission.
+          .row: .btn-group.mx-auto
+            a.btn.btn-outline-light.mx-auto target='_blank' rel='noopener' href='https://www.speedrun.com/api/auth' onclick='document.getElementById("api-key").focus()'
+              => image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
+              ' Copy Speedrun.com API Key
+          .row.text-light.m-2
+            p
+              ' (you can also access it from Speedrun.com &rarr; Settings &rarr; API Key)
+            p Paste the API key here:
+            = f.text_field(:api_key, id: 'api-key', class: 'form-control', placeholder: 'Paste the API key here', spellcheck: false)
+        - if controller_name == 'runs'
+          .modal-footer.bg-dark: .float-right: .btn-group = f.submit('Next', class: 'btn btn-success')
+        - else
+          .modal-footer.bg-dark: .float-right: .btn-group = f.submit('Save', class: 'btn btn-success')

--- a/app/views/users/show.slim
+++ b/app/views/users/show.slim
@@ -7,14 +7,13 @@
     span style='margin-right: .5em;'
       img src=@user.avatar width=50 height=50
     span = user_badge(@user)
-  - if @user.twitch.present?
-    h6
-      a.btn.btn-dark target='_blank' href=@user.twitch.url
+  .mb-2
+    - if @user.twitch.present?
+      a.btn.btn-twitch.mr-2.tip title='Watch on Twitch' href=@user.twitch.url
         => icon('fab', 'twitch')
-        span = @user
-  h6
-    - @user.games.named.each do |game|
-      => link_to(game.srdc.try(:shortname) || game.name, game, class: 'badge badge-primary', title: game.name)
+    - if @user.srdc.present?
+      a.btn.btn-srdc.tip title='Visit on Speedrun.com' href=@user.srdc.url
+        => image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
 article
   .row
     .col-lg-12

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,15 +48,18 @@ Rails.application.routes.draw do
 
   get '/:run/compare/:comparison_run', to: 'runs#compare',  as: :compare
 
-  get '/auth/patreon',          to: 'patreon_users#out'
-  get '/auth/patreon/callback', to: 'patreon_users#in'
-  get '/auth/patreon/unlink',   to: 'patreon_users#unlink'
+  get '/auth/twitch/callback', to: 'twitch_users#in'
+  get '/auth/twitch/unlink',   to: 'twitch_users#unlink'
 
   get '/auth/google/callback', to: 'google_users#in'
   get '/auth/google/unlink',   to: 'google_users#unlink'
 
-  get '/auth/twitch/callback', to: 'twitch_users#in'
-  get '/auth/twitch/unlink',   to: 'twitch_users#unlink'
+  get '/auth/patreon',          to: 'patreon_users#out'
+  get '/auth/patreon/callback', to: 'patreon_users#in'
+  get '/auth/patreon/unlink',   to: 'patreon_users#unlink'
+
+  post   '/auth/srdc', to: 'speedrun_dot_com_users#create',  as: :speedrun_dot_com_users
+  delete '/auth/srdc', to: 'speedrun_dot_com_users#destroy', as: :speedrun_dot_com_user
 
   get '/auth/failure', to: 'sessions#failure'
 

--- a/db/migrate/20190214000759_create_speedrun_dot_com_users.rb
+++ b/db/migrate/20190214000759_create_speedrun_dot_com_users.rb
@@ -1,0 +1,14 @@
+class CreateSpeedrunDotComUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :speedrun_dot_com_users, id: :uuid do |t|
+      t.belongs_to :user, foreign_key: true, null: false, index: {unique: true}
+
+      t.string :srdc_id, null: false, index: {unique: true}
+      t.string :name,    null: false
+      t.string :url,     null: false
+      t.string :api_key, null: false, index: {unique: true}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -306,6 +306,19 @@ ActiveRecord::Schema.define(version: 2019_02_20_233803) do
     t.index ["shortname"], name: "index_speedrun_dot_com_games_on_shortname"
   end
 
+  create_table "speedrun_dot_com_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "srdc_id", null: false
+    t.string "name", null: false
+    t.string "url", null: false
+    t.string "api_key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["api_key"], name: "index_speedrun_dot_com_users_on_api_key", unique: true
+    t.index ["srdc_id"], name: "index_speedrun_dot_com_users_on_srdc_id", unique: true
+    t.index ["user_id"], name: "index_speedrun_dot_com_users_on_user_id", unique: true
+  end
+
   create_table "splits", id: :serial, force: :cascade do |t|
     t.integer "run_id"
     t.integer "position"
@@ -371,6 +384,7 @@ ActiveRecord::Schema.define(version: 2019_02_20_233803) do
   add_foreign_key "speed_runs_live_games", "games"
   add_foreign_key "speedrun_dot_com_categories", "categories"
   add_foreign_key "speedrun_dot_com_games", "games"
+  add_foreign_key "speedrun_dot_com_users", "users"
   add_foreign_key "splits", "runs"
   add_foreign_key "twitch_users", "users"
 end

--- a/lib/speedrundotcom.rb
+++ b/lib/speedrundotcom.rb
@@ -63,6 +63,12 @@ module SpeedrunDotCom
   end
 
   class User
+    def self.from_api_key(api_key)
+      JSON.parse(SpeedrunDotCom.route['/profile'].get('X-API-Key' => api_key).body)['data']
+    rescue RestClient::Forbidden
+      nil
+    end
+
     def self.twitch_login(id)
       begin
         res = get(id)

--- a/lib/speedrundotcom.rb
+++ b/lib/speedrundotcom.rb
@@ -26,6 +26,7 @@ module SpeedrunDotCom
 
     def self.url_from_id(id)
       return nil if id.blank?
+
       "https://www.speedrun.com/run/#{CGI.escape(id)}"
     end
 


### PR DESCRIPTION
Adds account links to Speedrun.com accounts. No benefit atm other than a link to your Speedrun.com profile from your Splits I/O profile page. As mentioned in #508, this is the next stepping stone to an auto-submit-to-Speedrun.com feature, and I didn't want to bundle it in the same branch since they're both pretty big features.

Speedrun.com has no OAuth support, so unfortunately we have to ask for the user's API key to do the hookup.