### PR TITLE
Fix handlebars compile warning and nil method call

### DIFF
--- a/app/controllers/runs/likes_controller.rb
+++ b/app/controllers/runs/likes_controller.rb
@@ -4,7 +4,7 @@ class Runs::LikesController < Runs::ApplicationController
 
   def create
     if cannot?(:create, RunLike)
-      redirect_to run_path(@run_like.run), alert: 'You do not have permission to like this run.'
+      redirect_to run_path(@run), alert: 'You do not have permission to like this run.'
       return
     end
 
@@ -28,7 +28,7 @@ class Runs::LikesController < Runs::ApplicationController
     @run = Run.find_by(id: params[:run].to_i(36))
     head :not_found if @run.nil?
   end
-  
+
   def set_run_like
     @run_like = RunLike.find_by(user: current_user, run: Run.find_by(id: params[:run].to_i(36)))
     head :not_found if @run_like.nil?

--- a/app/views/pages/faq.slim
+++ b/app/views/pages/faq.slim
@@ -210,7 +210,7 @@ article.mt-4
           info, among other things.
       .card-footer
         .btn-group.float-right
-          a.btn.btn-dark href='https://github.com/batedurdonnadie/salty_bot'
+          a.btn.btn-dark href='https://github.com/batedurgonnadie/salty_bot'
             => icon('fab', 'github')
             | Source
           a.btn.btn-primary href='http://leagueofnewbs.com/twitch/salty' Website

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,6 +1,10 @@
 const { environment } = require('@rails/webpacker')
 const webpack = require('webpack')
 
+environment.config.set('resolve.alias', {
+  handlebars: 'handlebars/dist/handlebars.js'
+})
+
 environment.plugins.prepend(
   'Provide',
   new webpack.ProvidePlugin({


### PR DESCRIPTION
Handlebars fix based off [this](https://github.com/wycats/handlebars.js/issues/953#issuecomment-239874313) comment.

For the `NoMethodError: undefined method 'run' for nil:NilClass`, `@run_like` will always be `nil` since we only set it in the `before_action` for the `destroy` method, but since `@run` is always defined just redirect directly back to it.