### PR TITLE
Remove toplevel option from v4 blueprint and add test

### DIFF
--- a/app/blueprints/api/v4/run_blueprint.rb
+++ b/app/blueprints/api/v4/run_blueprint.rb
@@ -9,7 +9,7 @@ class Api::V4::RunBlueprint < Blueprinter::Base
   association :game, blueprint: Api::V4::GameBlueprint
   association :category, blueprint: Api::V4::CategoryBlueprint
   association :segments, blueprint: Api::V4::SegmentBlueprint
-  association :histories, blueprint: Api::V4::RunHistoryBlueprint, if: ->(_, options) { options[:toplevel] == :run && options[:historic] }
+  association :histories, blueprint: Api::V4::RunHistoryBlueprint, if: ->(_, options) { options[:historic] }
   association :runners, blueprint: Api::V4::UserBlueprint do |run, _|
     ([] << run.user).compact
   end

--- a/spec/controllers/api/v4/runs_controller_spec.rb
+++ b/spec/controllers/api/v4/runs_controller_spec.rb
@@ -102,6 +102,7 @@ describe Api::V4::RunsController do
     context 'for an existing run' do
       let(:run) { create(:run, :owned) }
       subject { get :show, params: {run: run.id36} }
+      let(:body) { JSON.parse(subject.body)['run'] }
 
       it 'returns a 200' do
         expect(subject).to have_http_status 200
@@ -109,12 +110,23 @@ describe Api::V4::RunsController do
 
       it 'renders a run schema' do
         expect(subject.body).to match_json_schema(:run)
+      end
+
+      it 'has no history present' do
+        expect(body['histories']).to be_nil
+      end
+
+      it 'has no segment histories present' do
+        body['segments'].each do |segment|
+          expect(segment['histories']).to be_nil
+        end
       end
     end
 
     context 'for an existing run with historic=1' do
       let(:run) { create(:run, :owned, :parsed) }
       subject { get :show, params: {run: run.id36, historic: '1'} }
+      let(:body) { JSON.parse(subject.body)['run'] }
 
       it 'returns a 200' do
         expect(subject).to have_http_status 200
@@ -122,6 +134,16 @@ describe Api::V4::RunsController do
 
       it 'renders a run schema' do
         expect(subject.body).to match_json_schema(:run)
+      end
+
+      it 'has a history present' do
+        expect(body['histories']).not_to be_nil
+      end
+
+      it 'has segment histories present' do
+        body['segments'].each do |segment|
+          expect(segment['histories']).not_to be_nil
+        end
       end
     end
 


### PR DESCRIPTION
toplevel is used on the run blueprint in v3 to verify that we want the splits to show up when accessing a run directly, but not when accessing runs in bulk on games/category pages.  v4 doesn't have this distinction.