### PR TITLE
Store run filesize in db (1/2)

### DIFF
--- a/app/models/concerns/unparsed_run.rb
+++ b/app/models/concerns/unparsed_run.rb
@@ -14,10 +14,12 @@ module UnparsedRun
         histories.delete_all
 
         parse_result = nil
+        size = 0
         file do |f|
           return false if f.nil?
 
           parse_result = Parser.parse(f.fileno)
+          size = File.size(f)
         end
 
         return false if parse_result.nil?
@@ -40,10 +42,10 @@ module UnparsedRun
         write_segment_histories(splits)
 
         update(
-          parsed_at: Time.now.utc,
-          program: timer_used.to_s,
-          attempts: parse_result[:attempts],
-          srdc_id: srdc_id || parse_result[:metadata][:srdc_id],
+          parsed_at:               Time.now.utc,
+          program:                 timer_used.to_s,
+          attempts:                parse_result[:attempts],
+          srdc_id:                 srdc_id || parse_result[:metadata][:srdc_id],
 
           realtime_duration_ms:    parse_result[:realtime_duration_ms] || 0,
           realtime_sum_of_best_ms: parse_result[:realtime_sum_of_best_ms],
@@ -51,8 +53,9 @@ module UnparsedRun
           gametime_duration_ms:    parse_result[:gametime_duration_ms] || 0,
           gametime_sum_of_best_ms: parse_result[:gametime_sum_of_best_ms],
 
-          total_playtime_ms: parse_result[:total_playtime_ms],
-          default_timing:    default_timing
+          total_playtime_ms:       parse_result[:total_playtime_ms],
+          default_timing:          default_timing,
+          filesize:                size
         )
 
         HighlightSuggestion.from_run(self)
@@ -144,8 +147,8 @@ module UnparsedRun
           next unless history[:attempt_number].to_i.positive?
 
           histories << SegmentHistory.new(
-            segment_id: ids[i],
-            attempt_number: history[:attempt_number].to_i,
+            segment_id:           ids[i],
+            attempt_number:       history[:attempt_number].to_i,
             realtime_duration_ms: history[:realtime_duration_ms],
             gametime_duration_ms: history[:gametime_duration_ms]
           )

--- a/app/models/concerns/unparsed_run.rb
+++ b/app/models/concerns/unparsed_run.rb
@@ -55,7 +55,7 @@ module UnparsedRun
 
           total_playtime_ms:       parse_result[:total_playtime_ms],
           default_timing:          default_timing,
-          filesize:                size
+          filesize_bytes:          size
         )
 
         HighlightSuggestion.from_run(self)

--- a/db/migrate/20190314234116_add_filesize_to_runs.rb
+++ b/db/migrate/20190314234116_add_filesize_to_runs.rb
@@ -1,0 +1,10 @@
+class AddFilesizeToRuns < ActiveRecord::Migration[5.2]
+  def up
+    add_column :runs, :filesize, :bigint
+    change_column_default :runs, :filesize, 0
+  end
+
+  def down
+    remove_column :runs, :filesize
+  end
+end

--- a/db/migrate/20190314234116_add_filesize_to_runs.rb
+++ b/db/migrate/20190314234116_add_filesize_to_runs.rb
@@ -1,10 +1,10 @@
 class AddFilesizeToRuns < ActiveRecord::Migration[5.2]
   def up
-    add_column :runs, :filesize, :bigint
-    change_column_default :runs, :filesize, 0
+    add_column :runs, :filesize_bytes, :bigint
+    change_column_default :runs, :filesize_bytes, 0
   end
 
   def down
-    remove_column :runs, :filesize
+    remove_column :runs, :filesize_bytes
   end
 end

--- a/db/migrate/20190315000310_backfill_add_filesize_to_runs.rb
+++ b/db/migrate/20190315000310_backfill_add_filesize_to_runs.rb
@@ -2,7 +2,7 @@ class BackfillAddFilesizeToRuns < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change
-    Run.in_batches.update_all filesize: 0
-    change_column_null :runs, :filesize, false
+    Run.in_batches.update_all filesize_bytes: 0
+    change_column_null :runs, :filesize_bytes, false
   end
 end

--- a/db/migrate/20190315000310_backfill_add_filesize_to_runs.rb
+++ b/db/migrate/20190315000310_backfill_add_filesize_to_runs.rb
@@ -1,0 +1,8 @@
+class BackfillAddFilesizeToRuns < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    Run.in_batches.update_all filesize: 0
+    change_column_null :runs, :filesize, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_20_233803) do
+ActiveRecord::Schema.define(version: 2019_03_15_000310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -212,7 +212,6 @@ ActiveRecord::Schema.define(version: 2019_02_20_233803) do
     t.string "program"
     t.string "claim_token"
     t.boolean "archived", default: false, null: false
-    t.string "video_url"
     t.string "srdc_id"
     t.integer "attempts"
     t.string "s3_filename", null: false
@@ -223,6 +222,8 @@ ActiveRecord::Schema.define(version: 2019_02_20_233803) do
     t.bigint "gametime_sum_of_best_ms"
     t.string "default_timing", default: "real", null: false
     t.bigint "total_playtime_ms"
+    t.string "video_url"
+    t.bigint "filesize", default: 0, null: false
     t.index ["category_id"], name: "index_runs_on_category_id"
     t.index ["s3_filename"], name: "index_runs_on_s3_filename"
     t.index ["user_id"], name: "index_runs_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -223,7 +223,7 @@ ActiveRecord::Schema.define(version: 2019_03_15_000310) do
     t.string "default_timing", default: "real", null: false
     t.bigint "total_playtime_ms"
     t.string "video_url"
-    t.bigint "filesize", default: 0, null: false
+    t.bigint "filesize_bytes", default: 0, null: false
     t.index ["category_id"], name: "index_runs_on_category_id"
     t.index ["s3_filename"], name: "index_runs_on_s3_filename"
     t.index ["user_id"], name: "index_runs_on_user_id"


### PR DESCRIPTION
This needs to be done in 2 stages, one to create the column and have new runs put into it, then a second to get the content length of existing runs and save that, then switch to `sum`ing the db column.