### PR TITLE
Store run filesize in db (2/2)

### DIFF
--- a/app/models/concerns/runner_user.rb
+++ b/app/models/concerns/runner_user.rb
@@ -5,13 +5,7 @@ module RunnerUser
 
   included do
     def s3_bytes_used(since: 100.years.ago)
-      runs.where('created_at > ?', since).sum do |run|
-        s3_run_object = $s3_bucket_internal.object("splits/#{run.s3_filename}")
-        s3_run_object.exists? ? s3_run_object.content_length : 0
-      rescue Aws::S3::Errors::Forbidden => e
-        Rollbar.warn(e, 'Missing/forbidden S3 file while counting runs', run_id: run.id, s3_filename: run.s3_filename)
-        0
-      end || 0
+      runs.where('created_at > ?', since).sum(:filesize_bytes)
     end
   end
 end

--- a/db/migrate/20190316060411_backfill_filesize.rb
+++ b/db/migrate/20190316060411_backfill_filesize.rb
@@ -1,0 +1,13 @@
+class BackfillFilesize < ActiveRecord::Migration[5.2]
+  def change
+    Run.where(filesize_bytes: 0).in_batches.each_record do |run|
+      begin
+        s3_run_object = $s3_bucket_internal.object("splits/#{run.s3_filename}")
+        if s3_run_object.exists?
+          run.update(filesize_bytes: s3_run_object.content_length)
+        end
+      rescue Aws::S3::Errors::Forbidden => e
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_15_000310) do
+ActiveRecord::Schema.define(version: 2019_03_16_060411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"


### PR DESCRIPTION
Stage 2 of storing the filesize from #522 .  Backfill the actual content_length's and sum the column instead of iterating the s3 objects.