### PR TITLE
Switch from delaying methods to dedicated jobs

### DIFF
--- a/app/channels/run_channel.rb
+++ b/app/channels/run_channel.rb
@@ -3,16 +3,4 @@ class RunChannel < ApplicationCable::Channel
     run = Run.find36(params[:run_id])
     stream_for(run)
   end
-
-  class << self
-    def broadcast_time_since_upload(id36)
-      run = Run.find36(id36)
-      RunChannel.broadcast_to(
-        run,
-        time_since_upload: ApplicationController.render(partial: 'runs/time_since_upload', locals: {run: run})
-      )
-    rescue ActiveRecord::RecordNotFound # If the run has been deleted since we scheduled this job, noop
-      nil
-    end
-  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,7 @@
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
+  retry_on ActiveRecord::Deadlocked
 
   # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  discard_on ActiveJob::DeserializationError
 end

--- a/app/jobs/broadcast_upload_job.rb
+++ b/app/jobs/broadcast_upload_job.rb
@@ -1,0 +1,10 @@
+class BroadcastUploadJob < ApplicationJob
+  queue_as :broadcast_upload
+
+  def perform(run)
+    RunChannel.broadcast_to(
+      run,
+      time_since_upload: ApplicationController.render(partial: 'runs/time_since_upload', locals: {run: run})
+    )
+  end
+end

--- a/app/jobs/discover_runner_job.rb
+++ b/app/jobs/discover_runner_job.rb
@@ -1,0 +1,13 @@
+class DiscoverRunnerJob < ApplicationJob
+  queue_as :discover_runner
+
+  def perform(run)
+    srdc_runner_id = SpeedrunDotCom::Run.runner_id(run.srdc_id)
+    return if srdc_runner_id.nil?
+
+    twitch_login = SpeedrunDotCom::User.twitch_login(srdc_runner_id)
+    return if twitch_login.blank?
+
+    run.update(user: User.find_by(name: twitch_login))
+  end
+end

--- a/app/jobs/discover_runner_job.rb
+++ b/app/jobs/discover_runner_job.rb
@@ -8,6 +8,6 @@ class DiscoverRunnerJob < ApplicationJob
     twitch_login = SpeedrunDotCom::User.twitch_login(srdc_runner_id)
     return if twitch_login.blank?
 
-    run.update(user: User.find_by(name: twitch_login))
+    run.update(user: User.joins(:twitch).find_by(twitch_users: {name: twitch_login}))
   end
 end

--- a/app/jobs/highlight_cleanup_job.rb
+++ b/app/jobs/highlight_cleanup_job.rb
@@ -1,0 +1,7 @@
+class HighlightCleanupJob < ApplicationJob
+  queue_as :highlight_cleanup
+
+  def perform(highlight_suggestion)
+    highlight_suggestion.destroy
+  end
+end

--- a/app/jobs/refresh_game_job.rb
+++ b/app/jobs/refresh_game_job.rb
@@ -1,0 +1,9 @@
+class RefreshGameJob < ApplicationJob
+  queue_as :refresh_game
+
+  def perform(game, category)
+    game.sync_with_srdc
+    game.sync_with_srl
+    category.sync_with_srdc
+  end
+end

--- a/app/jobs/sync_user_follows_job.rb
+++ b/app/jobs/sync_user_follows_job.rb
@@ -1,0 +1,23 @@
+class SyncUserFollowsJob < ApplicationJob
+  queue_as :sync_user_follows
+
+  def perform(user, twitch_user)
+    ActiveRecord::Base.transaction do
+      current_followed_users = User.joins(:twitch).where(
+        twitch_users: {twitch_id: Twitch::Follows.followed_ids(twitch_user.twitch_id)}
+      )
+
+      TwitchUserFollow.where(
+        from_user: user,
+        to_user:   (user.twitch_follows - current_followed_users)
+      ).destroy_all
+
+      TwitchUserFollow.import!((current_followed_users - user.twitch_follows).map do |u|
+        TwitchUserFollow.new(from_user: user, to_user: u)
+      end)
+    end
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid => e
+    twitch_user.update(follows_synced_at: Time.new.utc(1970))
+    raise e
+  end
+end

--- a/app/models/concerns/srdc_run.rb
+++ b/app/models/concerns/srdc_run.rb
@@ -13,16 +13,5 @@ module SRDCRun
     def srdc_url=(url)
       srdc_id = SpeedrunDotCom::Run.id_from_url(url)
     end
-
-    def set_runner_from_srdc
-      return if srdc_id.nil? || user.present?
-
-      srdc_runner_id = SpeedrunDotCom::Run.runner_id(srdc_id)
-      return if srdc_runner_id.nil?
-      twitch_login = SpeedrunDotCom::User.twitch_login(srdc_runner_id)
-      return if twitch_login.blank?
-
-      update(user: User.find_by(name: twitch_login))
-    end
   end
 end

--- a/app/models/highlight_suggestion.rb
+++ b/app/models/highlight_suggestion.rb
@@ -10,6 +10,8 @@ class HighlightSuggestion < ApplicationRecord
     def from_run(run)
       return if run.user.nil? || run.user.twitch.nil?
 
+      return run.highlight_suggestion if run.highlight_suggestion.present?
+
       pb = run.histories.where.not(started_at: nil, ended_at: nil).find_by(
         realtime_duration_ms: run.duration_ms(Run::REAL),
         gametime_duration_ms: run.duration_ms(Run::GAME)
@@ -42,7 +44,7 @@ class HighlightSuggestion < ApplicationRecord
             end
           )
           # 60 days is life of archives for Partners / Twitch Prime members
-          highlight_suggestion.delay(run_at: video_start + 60.days).destroy if highlight_suggestion.persisted?
+          HighlightCleanupJob.set(wait: 60.days).perform_later(highlight_suggestion) if highlight_suggestion.persisted?
           return highlight_suggestion
         end
       end

--- a/app/models/highlight_suggestion.rb
+++ b/app/models/highlight_suggestion.rb
@@ -44,7 +44,9 @@ class HighlightSuggestion < ApplicationRecord
             end
           )
           # 60 days is life of archives for Partners / Twitch Prime members
-          HighlightCleanupJob.set(wait: 60.days).perform_later(highlight_suggestion) if highlight_suggestion.persisted?
+          if highlight_suggestion.persisted?
+            HighlightCleanupJob.set(wait_until: video_start + 60.days).perform_later(highlight_suggestion)
+          end
           return highlight_suggestion
         end
       end

--- a/app/models/twitch_user.rb
+++ b/app/models/twitch_user.rb
@@ -33,27 +33,6 @@ class TwitchUser < ApplicationRecord
     twitch_user
   end
 
-  def sync_follows!
-    ActiveRecord::Base.transaction do
-      current_followed_users = User.joins(:twitch).where(
-        twitch_users: {twitch_id: Twitch::Follows.followed_ids(twitch_id)}
-      )
-
-      # If TwitchUserFollow is changed to have child records or destroy callbacks, change this to destroy_all
-      TwitchUserFollow.where(
-        from_user: user,
-        to_user: (user.twitch_follows - current_followed_users)
-      ).delete_all
-
-      TwitchUserFollow.import!((current_followed_users - user.twitch_follows).map do |u|
-        TwitchUserFollow.new(from_user: user, to_user: u)
-      end)
-    end
-  rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid => e
-    update(follows_synced_at: Time.new(1970))
-    raise e
-  end
-
   def self.default_avatar
     'https://static-cdn.jtvnw.net/jtv_user_pictures/xarth/404_user_150x150.png'
   end

--- a/db/migrate/20190402122033_cleanup_jobs.rb
+++ b/db/migrate/20190402122033_cleanup_jobs.rb
@@ -2,8 +2,22 @@ class CleanupJobs < ActiveRecord::Migration[6.0]
   def change
     # Remove all broken destroy jobs
     Delayed::Job.all.each do |job|
-      if job.name == 'HighlightSuggestion.destroy'
+      case j.name
+      when 'HighlightSuggestion.destroy'
+        # This job is broken
         job.destroy
+      when 'HighlightSuggestion#destroy'
+        run = Run.find(job.payload_object.run_id)
+        HighlightCleanupJob.set(wait: (Time.now.utc - job.run_at).seconds).perform_later(run.highlight_suggestion)
+      when 'RunChannel.broadcast_time_since_upload'
+        run = Run.find36(job.payload_object.args.first)
+        BroadcastUploadJob.set(wait: (Time.now.utc - job.run_at).seconds).perform_later(run)
+      when 'Run#refresh_game'
+        run = job.payload_object.object
+        RefreshGameJob.perform_later(run.game, run.category)
+      when 'Delayed::PerformableMethod'
+        # These jobs are highlight suggestions that are deleted
+        job.destory
       end
     end
 

--- a/db/migrate/20190402122033_cleanup_jobs.rb
+++ b/db/migrate/20190402122033_cleanup_jobs.rb
@@ -1,0 +1,15 @@
+class CleanupJobs < ActiveRecord::Migration[6.0]
+  def change
+    # Remove all broken destroy jobs
+    Delayed::Job.all.each do |job|
+      if job.name == 'HighlightSuggestion.destroy'
+        job.destroy
+      end
+    end
+
+    # Delete any suggestions that resulted in broken jobs
+    HighlightSuggestion.where('created_at > ?', 60.days.ago) do |suggestion|
+      suggestion.destroy
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_16_060411) do
+ActiveRecord::Schema.define(version: 2019_04_02_122033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -72,7 +72,7 @@ describe Run, type: :model do
       end
 
       it 'tries to fetch its runner from speedrun.com' do
-        run.set_runner_from_srdc
+        DiscoverRunnerJob.perform_now(run)
       end
     end
   end


### PR DESCRIPTION
This also includes a migration for cleaning up *most* of the broken jobs in the db.


Pros:
- First class integration with Rails
- Can change code inside job and next run will apply it (even if it errors on the first run)
- All delayed code is in one folder

Cons:
- Added complexity (more places to look for running code)
- Lose some Delayed Job specific callbacks (Rails has most of the same callbacks though)