### PR TITLE
Autoroutes

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -87,16 +87,18 @@ class Category < ApplicationRecord
     end
   end
 
-  # route returns a run whose route is the most popular in this category, as determined by runs sharing segment names
-  # and order.
+  # route returns a run whose route is the most popular in this category, as determined by the number of runs sharing
+  # its segment names and order. Returns nil if no runs exist in this category.
   def route
-    Run.find(
-      Run.select('MIN(runs.id) as id').
+    result = Run.select('MIN(runs.id) as id').
       joins(:segments).
       where(category: self).
       group(:segment_number, :name).
       order('COUNT(*) DESC').
-      first.id
-    )
+      first
+
+    return nil if result.nil?
+
+    Run.find(result.id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -94,7 +94,7 @@ class Category < ApplicationRecord
       joins(:segments).
       where(category: self).
       group(:segment_number, :name).
-      order('COUNT(*) DESC').
+      order(Arel.sql('COUNT(*) DESC')).
       first
 
     return nil if result.nil?

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -86,4 +86,17 @@ class Category < ApplicationRecord
       destroy
     end
   end
+
+  # route returns a run whose route is the most popular in this category, as determined by runs sharing segment names
+  # and order.
+  def route
+    Run.find(
+      Run.select('MIN(runs.id) as id').
+      joins(:segments).
+      where(category: self).
+      group(:segment_number, :name).
+      order('COUNT(*) DESC').
+      first.id
+    )
+  end
 end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -38,7 +38,7 @@ class Run < ApplicationRecord
   scope :by_category, ->(category) { where(category: category) }
   scope :nonempty, -> { where('realtime_duration_ms != 0') }
   scope :owned, -> { where.not(user: nil) }
-  scope :unarchived, -> { where(archived: false) }
+  scope :unarchived, -> { where(archived: false).where.not(user: nil) }
   scope :categorized, lambda {
     joins(:category).where.not(categories: {name: nil}).joins(:game).where.not(games: {name: nil})
   }

--- a/app/views/games/categories/show.slim
+++ b/app/views/games/categories/show.slim
@@ -10,6 +10,11 @@
   = render partial: 'games/categories/title', locals: {category: @category}
 
 article data-turbolinks-temporary=true
+  .card.mb-4 style='width: 18rem'
+    .card-body
+      h5.card-title #{@category.name} Route
+      p.card-text Automatically determined based on popularity
+      = render partial: 'runs/export_button', locals: {run: @category.route, button_text: 'Download', force_route_only: true}
   .card
     .card-header
       = render partial: 'shared/category_tabs', locals: {game: @game, current_category: @category, link_type: :normal}

--- a/app/views/games/categories/show.slim
+++ b/app/views/games/categories/show.slim
@@ -10,11 +10,13 @@
   = render partial: 'games/categories/title', locals: {category: @category}
 
 article data-turbolinks-temporary=true
-  .card.mb-4 style='width: 18rem'
-    .card-body
-      h5.card-title #{@category.name} Route
-      p.card-text Automatically determined based on popularity
-      = render partial: 'runs/export_button', locals: {run: @category.route, button_text: 'Download', force_route_only: true}
+  - route = @category.route
+  - if @category.route.present?
+    .card.mb-4 style='width: 18rem'
+      .card-body
+        h5.card-title #{@category.name} Route
+        p.card-text Automatically determined based on popularity
+        = render partial: 'runs/export_button', locals: {run: route, button_text: 'Download', force_route_only: true}
   .card
     .card-header
       = render partial: 'shared/category_tabs', locals: {game: @game, current_category: @category, link_type: :normal}

--- a/app/views/runs/_export_button.slim
+++ b/app/views/runs/_export_button.slim
@@ -1,15 +1,16 @@
 button#export-link.btn.btn-outline-light.dropdown-toggle href='#' role='button' aria={haspopup: true, expanded: false} data={toggle: 'dropdown'}
   => icon('fas', 'download')
-  span Export
+  = defined?(button_text) ? button_text : 'Export'
 #export-menu.dropdown-menu.bg-dark aria-labelledby='export-link'
-  form.px-4.pt-2: .form-group: .form-check
-    input#route-check.form-check-input type='checkbox' checked=true
-    label#route-check-label.form-check-label for='route-check'
-      ' Route only
-      small.tip(
-        title="When checked, Splits I/O won't include attempt history and gold times in the export.
-        Only applies to Generic Formats and Local Timers. If you're not sure, leave this checked."
-      ) = icon('fas', 'question-circle')
+  form.px-4.pt-2 style=('display: none' if defined?(force_route_only) && force_route_only)
+    .form-group: .form-check
+      input#route-check.form-check-input type='checkbox' checked=true
+      label#route-check-label.form-check-label for='route-check'
+        ' Route only
+        small.tip(
+          title="When checked, Splits I/O won't include attempt history and gold times in the export.
+          Only applies to Generic Formats and Local Timers. If you're not sure, leave this checked."
+        ) = icon('fas', 'question-circle')
   h6.dropdown-header.text-success Generic Formats
   a.dropdown-item.can-strip-history.text-light data={turbolinks: false} href=download_path(run, ExchangeFormat.to_sym)
     => icon('fas', 'file-download')

--- a/app/views/runs/_export_button.slim
+++ b/app/views/runs/_export_button.slim
@@ -1,8 +1,8 @@
 button#export-link.btn.btn-outline-light.dropdown-toggle href='#' role='button' aria={haspopup: true, expanded: false} data={toggle: 'dropdown'}
   => icon('fas', 'download')
-  = defined?(button_text) ? button_text : 'Export'
+  = local_assigns.fetch(:button_text, 'Export')
 #export-menu.dropdown-menu.bg-dark aria-labelledby='export-link'
-  form.px-4.pt-2 style=('display: none' if defined?(force_route_only) && force_route_only)
+  form.px-4.pt-2 style=('display: none' if local_assigns.fetch(:force_route_only, false))
     .form-group: .form-check
       input#route-check.form-check-input type='checkbox' checked=true
       label#route-check-label.form-check-label for='route-check'

--- a/app/views/runs/_title.slim
+++ b/app/views/runs/_title.slim
@@ -20,7 +20,7 @@ h5
 .btn-toolbar role='toolbar' aria={label: 'Run navigation'}
   .btn-group.m-2 role='group' aria={label: 'Run navigation'}
     .btn-group role='group'
-      = render partial: 'export_button', locals: {run: run, timing: timing}
+      = render partial: 'export_button', locals: {run: run}
     .btn-group role='group'
       - if run.category
         - if !run.belongs_to?(current_user) && current_user.try(:runs?, run.category)


### PR DESCRIPTION
Automatically determine the most popular route (i.e. arrangement of splits) for each category and place a download link to it on the game and category pages.

<img width="515" alt="Screen Shot 2019-04-06 at 18 45 48" src="https://user-images.githubusercontent.com/438911/55677441-435fb900-589c-11e9-9ec0-a065a7724ea4.png">

Came up with this one on the toilet an hour ago when I forgot to bring my Switch with me. TODO: Stop bringing distractions to the toilet.