### PR TITLE
Add dropdown to show previous runs in pb tables

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -90,12 +90,12 @@ class Category < ApplicationRecord
   # route returns a run whose route is the most popular in this category, as determined by the number of runs sharing
   # its segment names and order. Returns nil if no runs exist in this category.
   def route
-    result = Run.select('MIN(runs.id) as id').
-      joins(:segments).
-      where(category: self).
-      group(:segment_number, :name).
-      order(Arel.sql('COUNT(*) DESC')).
-      first
+    result = Run.select('MIN(runs.id) as id')
+                .joins(:segments)
+                .where(category: self)
+                .group(:segment_number, :name)
+                .order(Arel.sql('COUNT(*) DESC'))
+                .first
 
     return nil if result.nil?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,4 +110,16 @@ class User < ApplicationRecord
   def likes?(run)
     RunLike.find_by(user: self, run: run)
   end
+
+  # Retrieve all runs scoped for a paginated page excluding already loaded runs
+  def old_runs_for_page(paged_runs)
+    ids = []
+    categories = []
+    paged_runs.map do |run|
+      ids << run.id
+      categories << run.category_id
+    end
+
+    runs.where(category_id: categories).where.not(id: ids)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,15 +63,11 @@ class User < ApplicationRecord
         .union_all(runs.by_category(nil))
   end
 
-  def non_pbs
-    ids = []
-    categories = []
-    pbs.map do |run|
-      ids << run.id
-      categories << run.category_id
-    end
-
-    runs.where(category_id: categories).where.not(id: ids)
+  # Takes array of category_ids, will limit returned runs to only those from those categories
+  def non_pbs(categories = [])
+    query = runs.where.not(id: pbs).where.not(category_id: nil)
+    query = query.where(category_id: categories) if categories.present?
+    query
   end
 
   def runs?(category)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,7 +63,8 @@ class User < ApplicationRecord
         .union_all(runs.by_category(nil))
   end
 
-  # Takes array of category_ids, will limit returned runs to only those from those categories
+  # Will filter returned runs to only those from the supplied categories if provided
+  # Accepts either an ActiveRecord::Relation of categories or a PORO Array of category ids
   def non_pbs(categories = [])
     query = runs.where.not(id: pbs).where.not(category_id: nil)
     query = query.where(category_id: categories) if categories.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,6 +63,17 @@ class User < ApplicationRecord
         .union_all(runs.by_category(nil))
   end
 
+  def non_pbs
+    ids = []
+    categories = []
+    pbs.map do |run|
+      ids << run.id
+      categories << run.category_id
+    end
+
+    runs.where(category_id: categories).where.not(id: ids)
+  end
+
   def runs?(category)
     runs.where(category: category).any?
   end
@@ -109,17 +120,5 @@ class User < ApplicationRecord
 
   def likes?(run)
     RunLike.find_by(user: self, run: run)
-  end
-
-  # Retrieve all runs scoped for a paginated page excluding already loaded runs
-  def old_runs_for_page(paged_runs)
-    ids = []
-    categories = []
-    paged_runs.map do |run|
-      ids << run.id
-      categories << run.category_id
-    end
-
-    runs.where(category_id: categories).where.not(id: ids)
   end
 end

--- a/app/views/runs/index.slim
+++ b/app/views/runs/index.slim
@@ -27,7 +27,8 @@
           = render partial: 'shared/run_table', locals: { \
             runs: current_user.pbs, \
             cols: %i[archived time name uploaded owner_controls rival], \
-            description: 'My Personal Bests' \
+            description: 'My Personal Bests', \
+            user: current_user \
           }.merge(sorting_info)
   - else
     article

--- a/app/views/runs/index.slim
+++ b/app/views/runs/index.slim
@@ -26,7 +26,7 @@
         .card.shadow
           = render partial: 'shared/run_table', locals: { \
             runs: current_user.pbs, \
-            cols: %i[time name uploaded owner_controls rival], \
+            cols: %i[archived time name uploaded owner_controls rival], \
             description: 'My Personal Bests' \
           }.merge(sorting_info)
   - else

--- a/app/views/runs/index.slim
+++ b/app/views/runs/index.slim
@@ -26,7 +26,8 @@
         .card.shadow
           = render partial: 'shared/run_table', locals: { \
             runs: current_user.pbs, \
-            cols: %i[archived time name uploaded owner_controls rival], \
+            cols: %i[time name uploaded owner_controls rival], \
+            col_options: {time: [:archived]}, \
             description: 'My Personal Bests', \
             user: current_user \
           }.merge(sorting_info)

--- a/app/views/shared/_run_table.slim
+++ b/app/views/shared/_run_table.slim
@@ -3,7 +3,7 @@
 / This allows us to blindly check the keys for items instead of wraping in `try`s
 - col_options = cols.to_h { |col| [col, []] }.merge(local_assigns.fetch(:col_options, {}))
 - runs = order_runs(runs).page(params[:page]).includes(:user, :game)
-- non_pbs_runs = user.non_pbs.group_by(&:category_id) if col_options[:time].include?(:archived)
+- non_pbs_runs = user.non_pbs(runs.map(&:category_id)).group_by(&:category_id) if col_options[:time].include?(:archived)
 - unless runs.any?
   center
     i No runs matched!

--- a/app/views/shared/_run_table.slim
+++ b/app/views/shared/_run_table.slim
@@ -3,7 +3,7 @@
 / This allows us to blindly check the keys for items instead of wraping in `try`s
 - col_options = cols.to_h { |col| [col, []] }.merge(local_assigns.fetch(:col_options, {}))
 - runs = order_runs(runs).page(params[:page]).includes(:user, :game)
-- all_runs = user.old_runs_for_page(runs) if col_options[:time].include?(:archived)
+- non_pbs_runs = user.non_pbs.group_by(&:category_id) if col_options[:time].include?(:archived)
 - unless runs.any?
   center
     i No runs matched!
@@ -36,9 +36,8 @@
                 / Make sure to not group runs with no category
                 - if col_options[:time].include?(:archived) && run.category_id.present?
                   / Gather only runs with the same category and sort by default timing ascending
-                  - old_runs = all_runs.filter { |r| r.category_id == run.category_id }
-                  - old_runs = old_runs.sort_by(&Run.duration_type(run.default_timing))
-                  - if old_runs.any?
+                  - old_runs = non_pbs_runs[run.category_id].try(:sort_by, &Run.duration_type(run.default_timing))
+                  - if old_runs.present?
                     span.dropdown-toggle.mr-2.cursor-pointer id="#{run.id36}-history-dropdown" data-toggle='dropdown'
                       = icon('fas', 'history')
                     span.dropdown-menu.bg-dark aria-labelledby="#{run.id36}-history-dropdown"

--- a/app/views/shared/_run_table.slim
+++ b/app/views/shared/_run_table.slim
@@ -1,6 +1,7 @@
 - description ||= nil
 - cols ||= [:runner, :time, :name, :rival, :uploaded]
 - runs = order_runs(runs).page(params[:page]).includes(:user, :game)
+- all_runs = current_user.runs.order(:realtime_duration_ms) if cols.include?(:archived)
 - unless runs.any?
   center
     i No runs matched!
@@ -29,7 +30,17 @@
             - if cols.include?(:runner)
               td.align-right = user_badge(run.user)
             - if cols.include?(:time)
-              td.align-right = run.duration.format
+              td.align-right
+                - if cols.include?(:archived) && run.category_id.present?
+                  - old_runs = all_runs.filter { |r| r.id != run.id && r.category_id == run.category_id }
+                  - if old_runs.length.positive?
+                    span.dropdown-toggle.mr-2 id="#{run.id36}-history-dropdown" data-toggle='dropdown'
+                      = icon('fas', 'history')
+                    span.dropdown-menu.bg-dark aria-labelledby="#{run.id36}-history-dropdown"
+                      h6.dropdown-header Past Times
+                      - old_runs.each do |old_run|
+                        a.dropdown-item.text-light href="#{run_path(old_run)}" = old_run.duration.format
+                = run.duration.format
             - if cols.include?(:name)
               td = link_to run, run_path(run), class: 'run-link'
             - if cols.include?(:rival)

--- a/app/views/shared/_run_table.slim
+++ b/app/views/shared/_run_table.slim
@@ -1,7 +1,7 @@
 - description ||= nil
 - cols ||= [:runner, :time, :name, :rival, :uploaded]
 - runs = order_runs(runs).page(params[:page]).includes(:user, :game)
-- all_runs = current_user.runs.order(:realtime_duration_ms) if cols.include?(:archived)
+- all_runs = user.runs.order(:realtime_duration_ms) if cols.include?(:archived)
 - unless runs.any?
   center
     i No runs matched!

--- a/app/views/shared/_run_table.slim
+++ b/app/views/shared/_run_table.slim
@@ -1,7 +1,9 @@
 - description ||= nil
 - cols ||= [:runner, :time, :name, :rival, :uploaded]
+/ This allows us to blindly check the keys for items instead of wraping in `try`s
+- col_options = cols.to_h { |col| [col, []] }.merge(local_assigns.fetch(:col_options), {})
 - runs = order_runs(runs).page(params[:page]).includes(:user, :game)
-- all_runs = user.runs.order(:realtime_duration_ms) if cols.include?(:archived)
+- all_runs = user.old_runs_for_page(runs) if col_options[:time].include?(:archived)
 - unless runs.any?
   center
     i No runs matched!
@@ -31,15 +33,18 @@
               td.align-right = user_badge(run.user)
             - if cols.include?(:time)
               td.align-right
-                - if cols.include?(:archived) && run.category_id.present?
-                  - old_runs = all_runs.filter { |r| r.id != run.id && r.category_id == run.category_id }
-                  - if old_runs.length.positive?
-                    span.dropdown-toggle.mr-2 id="#{run.id36}-history-dropdown" data-toggle='dropdown'
+                / Make sure to not group runs with no category
+                - if col_options[:time].include?(:archived) && run.category_id.present?
+                  / Gather only runs with the same category and sort by default timing ascending
+                  - old_runs = all_runs.filter { |r| r.category_id == run.category_id }
+                  - old_runs = old_runs.sort_by(&Run.duration_type(run.default_timing))
+                  - if old_runs.any?
+                    span.dropdown-toggle.mr-2.cursor-pointer id="#{run.id36}-history-dropdown" data-toggle='dropdown'
                       = icon('fas', 'history')
                     span.dropdown-menu.bg-dark aria-labelledby="#{run.id36}-history-dropdown"
                       h6.dropdown-header Past Times
                       - old_runs.each do |old_run|
-                        a.dropdown-item.text-light href="#{run_path(old_run)}" = old_run.duration.format
+                        a.dropdown-item.text-secondary href=run_path(old_run) = old_run.duration.format
                 = run.duration.format
             - if cols.include?(:name)
               td = link_to run, run_path(run), class: 'run-link'

--- a/app/views/shared/_run_table.slim
+++ b/app/views/shared/_run_table.slim
@@ -1,7 +1,7 @@
 - description ||= nil
 - cols ||= [:runner, :time, :name, :rival, :uploaded]
 / This allows us to blindly check the keys for items instead of wraping in `try`s
-- col_options = cols.to_h { |col| [col, []] }.merge(local_assigns.fetch(:col_options), {})
+- col_options = cols.to_h { |col| [col, []] }.merge(local_assigns.fetch(:col_options, {}))
 - runs = order_runs(runs).page(params[:page]).includes(:user, :game)
 - all_runs = user.old_runs_for_page(runs) if col_options[:time].include?(:archived)
 - unless runs.any?

--- a/app/views/users/show.slim
+++ b/app/views/users/show.slim
@@ -21,7 +21,8 @@ article
       .card.shadow
         = render partial: 'shared/run_table', locals: { \
           runs: @user.pbs, \
-          cols: %i[archived time name uploaded], \
+          cols: %i[time name uploaded], \
+          col_options: {time: [:archived]}, \
           description: 'Personal Bests', \
           user: @user \
         }.merge(sorting_info)

--- a/app/views/users/show.slim
+++ b/app/views/users/show.slim
@@ -12,7 +12,7 @@
       a.btn.btn-twitch.mr-2.tip title='Watch on Twitch' href=@user.twitch.url
         => icon('fab', 'twitch')
     - if @user.srdc.present?
-      a.btn.btn-srdc.mr-2.tip title='Visit on Speedrun.com' href=@user.srdc.url
+      a.btn.btn-srdc.tip title='Visit on Speedrun.com' href=@user.srdc.url
         => image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
 
 article

--- a/app/views/users/show.slim
+++ b/app/views/users/show.slim
@@ -14,25 +14,13 @@
     - if @user.srdc.present?
       a.btn.btn-srdc.mr-2.tip title='Visit on Speedrun.com' href=@user.srdc.url
         => image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
-    .btn-group
-      a.btn.tip{
-        class=(params[:archived] ? 'btn-secondary' : 'btn-primary')
-        title="View PB's By #{@user}"
-        href=user_path(@user, request.query_parameters.except(:archived))
-      }
-        => icon('fas', 'tachometer-alt')
-      a.btn.tip{
-        class=(params[:archived] ? 'btn-primary' : 'btn-secondary')
-        title="View All Runs By #{@user}"
-        href=user_path(@user, request.query_parameters.merge(archived: true))
-      }
-        => icon('fas', 'globe-americas')
+
 article
   .row
     .col-lg-12
       .card.shadow
         = render partial: 'shared/run_table', locals: { \
-          runs: params[:archived] ? @user.runs : @user.pbs, \
-          cols: %i[time name uploaded], \
-          description: params[:archived] ? 'All Runs' : 'Personal Bests' \
+          runs: @user.pbs, \
+          cols: %i[archived time name uploaded], \
+          description: 'Personal Bests' \
         }.merge(sorting_info)

--- a/app/views/users/show.slim
+++ b/app/views/users/show.slim
@@ -22,5 +22,6 @@ article
         = render partial: 'shared/run_table', locals: { \
           runs: @user.pbs, \
           cols: %i[archived time name uploaded], \
-          description: 'Personal Bests' \
+          description: 'Personal Bests', \
+          user: @user \
         }.merge(sorting_info)

--- a/app/views/users/show.slim
+++ b/app/views/users/show.slim
@@ -12,14 +12,27 @@
       a.btn.btn-twitch.mr-2.tip title='Watch on Twitch' href=@user.twitch.url
         => icon('fab', 'twitch')
     - if @user.srdc.present?
-      a.btn.btn-srdc.tip title='Visit on Speedrun.com' href=@user.srdc.url
+      a.btn.btn-srdc.mr-2.tip title='Visit on Speedrun.com' href=@user.srdc.url
         => image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
+    .btn-group
+      a.btn.tip{
+        class=(params[:archived] ? 'btn-secondary' : 'btn-primary')
+        title="View PB's By #{@user}"
+        href=user_path(@user, request.query_parameters.except(:archived))
+      }
+        => icon('fas', 'tachometer-alt')
+      a.btn.tip{
+        class=(params[:archived] ? 'btn-primary' : 'btn-secondary')
+        title="View All Runs By #{@user}"
+        href=user_path(@user, request.query_parameters.merge(archived: true))
+      }
+        => icon('fas', 'globe-americas')
 article
   .row
     .col-lg-12
       .card.shadow
         = render partial: 'shared/run_table', locals: { \
-          runs: @user.pbs, \
+          runs: params[:archived] ? @user.runs : @user.pbs, \
           cols: %i[time name uploaded], \
-          description: 'Personal Bests' \
+          description: params[:archived] ? 'All Runs' : 'Personal Bests' \
         }.merge(sorting_info)


### PR DESCRIPTION
Switch is only on the profile page for a user, and allows anyone to toggle it.  Wasn't sure if it should go there or on the homepage and only allow people to see their own archived runs.