### PR TITLE
Use Twitch bearer tokens whenever possible

### DIFF
--- a/app/jobs/sync_user_follows_job.rb
+++ b/app/jobs/sync_user_follows_job.rb
@@ -4,7 +4,7 @@ class SyncUserFollowsJob < ApplicationJob
   def perform(user, twitch_user)
     ActiveRecord::Base.transaction do
       current_followed_users = User.joins(:twitch).where(
-        twitch_users: {twitch_id: Twitch::Follows.followed_ids(twitch_user.twitch_id)}
+        twitch_users: {twitch_id: twitch_user.followed_ids}
       )
 
       TwitchUserFollow.where(

--- a/app/models/highlight_suggestion.rb
+++ b/app/models/highlight_suggestion.rb
@@ -18,7 +18,7 @@ class HighlightSuggestion < ApplicationRecord
       )
       return if pb.nil?
 
-      Twitch::Videos.recent(run.user.twitch.twitch_id, type: :archive).each do |video|
+      run.user.twitch.videos.each do |video|
         match = /^((\d+)h)?((\d+)m)?((\d+)s)?$/.match(video['duration'])
 
         hours   = match[2].to_i.hours

--- a/app/models/twitch_user.rb
+++ b/app/models/twitch_user.rb
@@ -36,4 +36,12 @@ class TwitchUser < ApplicationRecord
   def self.default_avatar
     'https://static-cdn.jtvnw.net/jtv_user_pictures/xarth/404_user_150x150.png'
   end
+
+  def videos
+    Twitch::Videos.recent(twitch_id, type: :archive, token: access_token)
+  end
+
+  def followed_ids
+    Twitch::Follows.followed_ids(twitch_id, token: access_token)
+  end
 end

--- a/lib/twitch.rb
+++ b/lib/twitch.rb
@@ -10,8 +10,8 @@ class Twitch
     end
 
     class << self
-      def get(id)
-        route(id).get(Twitch.headers)['data']
+      def get(id, token: nil)
+        route(id).get(Twitch.headers(token))['data']
       end
 
       def route(id)
@@ -21,11 +21,11 @@ class Twitch
   end
 
   module Follows
-    def self.followed_ids(id)
+    def self.followed_ids(id, token: nil)
       cursor = nil
       ids = []
       loop do
-        response = get(id, cursor)
+        response = get(id, token: token, cursor: cursor)
         break if response.code != 200
         body = JSON.parse(response.body)
         break if body['data'].empty?
@@ -39,11 +39,11 @@ class Twitch
     end
 
     class << self
-      def get(id, cursor)
-        route(id, cursor).get(Twitch.headers)
+      def get(id, token: nil, cursor: nil)
+        route(id, token: token, cursor: cursor).get(Twitch.headers(token: token))
       end
 
-      def route(id, cursor)
+      def route(id, cursor: nil)
         Twitch.route["/users/follows?#{{
           from_id: id,
           first: 100,
@@ -54,13 +54,16 @@ class Twitch
   end
 
   module Videos
-    # recent returns recent videos on the channel of the given Twitch user ID. type can be :all, :upload, :archive, or
-    # :highlight.
-    def self.recent(id, type: :all)
+    # recent returns videos for the given Twitch user ID from most to least recent. type can be :all, :upload, :archive,
+    # or :highlight.
+    def self.recent(id, type: :all, token: nil)
+      # To the caller this feels as if we're returning an array of all Twitch videos, but it's just an enumerator that
+      # lazily fetches more videos only if the caller tries to look at them.
       cursor = nil
+
       Enumerator.new do |yielder|
         loop do
-          response = get(id, type, cursor: cursor)
+          response = Videos.get(id, type, token: token, cursor: cursor)
           raise StopIteration if response.code != 200
           body = JSON.parse(response.body)
           raise StopIteration if body['data'].empty?
@@ -73,19 +76,17 @@ class Twitch
       end.lazy
     end
 
-    class << self
-      def get(id, type, cursor: nil)
-        route(id, type, cursor).get(Twitch.headers)
-      end
+    def self.get(id, type, token: nil, cursor: nil)
+      Videos.route(id, type, cursor: cursor).get(Twitch.headers(token))
+    end
 
-      def route(id, type, cursor)
-        return Twitch.route["/videos?#{{
-          user_id: id,
-          type: type,
-          first: 100,
-          after: cursor
-        }.to_query}"]
-      end
+    def self.route(id, type, cursor: nil)
+      return Twitch.route["/videos?#{{
+        user_id: id,
+        type: type,
+        first: 100,
+        after: cursor
+      }.to_query}"]
     end
   end
 
@@ -94,8 +95,16 @@ class Twitch
       RestClient::Resource.new('https://api.twitch.tv/helix')
     end
 
-    def headers
-      {'Client-ID' => ENV['TWITCH_CLIENT_ID']}
+    # headers returns the HTTP headers we should send with the Twitch API request. It accepts a bearer token; if this
+    # request is on behalf of a user, you should pass one to improve rate limits (from 30/day to 800/user/day).
+    #
+    # See: https://dev.twitch.tv/docs/api/guide/#rate-limits
+    def headers(token: nil)
+      if token.present?
+        {'Authorization' => "Bearer #{token}"}
+      else
+        {'Client-ID' => ENV['TWITCH_CLIENT_ID']}
+      end
     end
   end
 end

--- a/lib/twitch.rb
+++ b/lib/twitch.rb
@@ -96,7 +96,7 @@ class Twitch
     end
 
     # headers returns the HTTP headers we should send with the Twitch API request. It accepts a bearer token; if this
-    # request is on behalf of a user, you should pass one to improve rate limits (from 30/day to 800/user/day).
+    # request is on behalf of a user, you should pass one to improve rate limits (from 30/min to 800/user/min).
     #
     # See: https://dev.twitch.tv/docs/api/guide/#rate-limits
     def headers(token: nil)


### PR DESCRIPTION
Start using bearer access tokens whenever possible when interacting with the Twitch API. We've been starting to hit the standard rate limit for application-scoped requests (30 / min), but by passing bearer tokens our limit goes up to 800 / user / min, I guess because it's proof we're acting on behalf of real users.