### PR TITLE
Support refreshing Twitch tokens

### DIFF
--- a/app/controllers/twitch_users_controller.rb
+++ b/app/controllers/twitch_users_controller.rb
@@ -2,8 +2,7 @@ class TwitchUsersController < ApplicationController
   include Authenticatable
 
   def in
-    auth = request.env['omniauth.auth']
-    twitch_user = TwitchUser.from_auth(auth, current_user)
+    twitch_user = TwitchUser.from_auth(request.env['omniauth.auth'], current_user)
     if twitch_user.errors.any?
       redirect_to redirect_path, alert: "Couldn't sign in: #{twitch_user.errors.full_messages.to_sentence} :("
       return

--- a/app/models/twitch_user.rb
+++ b/app/models/twitch_user.rb
@@ -22,12 +22,13 @@ class TwitchUser < ApplicationRecord
     end
 
     twitch_user.assign_attributes(
-      access_token: auth.credentials.token,
-      name:         auth.info.nickname,
-      display_name: auth.info.name,
-      email:        auth.info.email,
-      avatar:       auth.info.image || TwitchUser.default_avatar,
-      url:          auth.info.urls.Twitch
+      access_token:  auth.credentials.token,
+      refresh_token: auth.credentials.refresh_token,
+      name:          auth.info.nickname,
+      display_name:  auth.info.name,
+      email:         auth.info.email,
+      avatar:        auth.info.image || TwitchUser.default_avatar,
+      url:           auth.info.urls.Twitch
     )
     twitch_user.save
     twitch_user
@@ -39,9 +40,29 @@ class TwitchUser < ApplicationRecord
 
   def videos
     Twitch::Videos.recent(twitch_id, type: :archive, token: access_token)
+  rescue RestClient::Unauthorized
+    refresh_tokens!
   end
 
   def followed_ids
     Twitch::Follows.followed_ids(twitch_id, token: access_token)
+  rescue RestClient::Unauthorized
+    refresh_tokens!
+  end
+
+  # refresh_tokens! updates the access token and refresh token for this user with a new one from the Twitch API.
+  def refresh_tokens!
+    update(Twitch.new_tokens!(refresh_token))
+  rescue RestClient::Unauthorized, RestClient::BadRequest
+    # If the refresh got 401 Unauthorized, we were probably de-authorized from using the user's Twitch account. If it
+    # got 400 Bad Request, we probably have a nil refresh token, perhaps because the authorization was created before we
+    # started saving them to the database.
+    #
+    # Ideally we'd destroy the TwitchUser here, but that may leave the user with no way to sign in. Instead, force a
+    # sign out so we can get some fresh tokens. Until that happens we technically have no way to verify this Twitch user
+    # and this Splits.io user are the same person, only that they once were in the past.
+    #
+    # Once we have linkless accounts, change this to destroy the TwitchUser.
+    user.sessions.destroy_all
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,8 @@ class User < ApplicationRecord
   has_many :access_grants, class_name: 'Doorkeeper::AccessGrant', dependent: :destroy, foreign_key: :resource_owner_id
   has_many :access_tokens, class_name: 'Doorkeeper::AccessToken', dependent: :destroy, foreign_key: :resource_owner_id
 
+  has_many :sessions, class_name: 'Authie::Session', as: :user, dependent: :destroy
+
   NAME_REGEX = /\A[A-Za-z0-9_]+\z/.freeze
 
   validates :name, presence: true, uniqueness: true, format: {with: NAME_REGEX}

--- a/db/migrate/20190511153212_add_refresh_token_to_twitch_users.rb
+++ b/db/migrate/20190511153212_add_refresh_token_to_twitch_users.rb
@@ -1,0 +1,5 @@
+class AddRefreshTokenToTwitchUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :twitch_users, :refresh_token, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_25_121602) do
+ActiveRecord::Schema.define(version: 2019_05_11_153212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -361,6 +361,7 @@ ActiveRecord::Schema.define(version: 2019_04_25_121602) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "url", null: false
+    t.string "refresh_token"
     t.index ["twitch_id"], name: "index_twitch_users_on_twitch_id", unique: true
     t.index ["user_id"], name: "index_twitch_users_on_user_id", unique: true
   end

--- a/lib/twitch.rb
+++ b/lib/twitch.rb
@@ -106,5 +106,23 @@ class Twitch
         {'Client-ID' => ENV['TWITCH_CLIENT_ID']}
       end
     end
+
+    # new_tokens! takes a user's current refresh token and returns a hash containing a fresh access token and refresh
+    # token e.g.
+    #
+    # {access_token: 'boop', refresh_token: 'beep'}
+    #
+    # Upon calling this method you should assume the old access token and refresh token are invalidated by Twitch.
+    # See https://dev.twitch.tv/docs/authentication/#refreshing-access-tokens.
+    def new_tokens!(refresh_token)
+      body = JSON.parse(RestClient::Resource.new('https://id.twitch.tv/oauth2')["/token?#{{
+        grant_type: 'refresh_token',
+        refresh_token: refresh_token,
+        client_id: ENV['TWITCH_CLIENT_ID'],
+        client_secret: ENV['TWITCH_CLIENT_SECRET']
+      }.to_query}"].post(nil))
+
+      {access_token: body['access_token'], refresh_token: body['refresh_token']}
+    end
   end
 end

--- a/spec/controllers/twitch_users_controller_spec.rb
+++ b/spec/controllers/twitch_users_controller_spec.rb
@@ -19,7 +19,8 @@ describe TwitchUsersController do
               urls: double(Twitch: 'https://www.twitch.tv/glacials')
             ),
             credentials: double(
-              token: '',
+              token: SecureRandom.uuid,
+              refresh_token: SecureRandom.uuid,
               expires_at: Time.now + 1.day
             )
           )


### PR DESCRIPTION
Add automatic support for refreshing Twitch access tokens when they're expired or otherwise not valid.

See https://dev.twitch.tv/docs/authentication/#refreshing-access-tokens

The Twitch API has always returned refresh tokens, but access tokens never actually expired so this was never critical. I'm adding it for future proofing and to solve bugs where the access token needs refreshing for other reasons (e.g. the user changes their Twitch password).