### PR TITLE
Rotate logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: bash
 sudo: required
 services:
   - docker
+before_install: # Update docker-compose; Travis's built-in one is old
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
 install:
   - docker-compose build
 script:

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,79 +1,62 @@
-version: '3'
+version: '3.7'
+x-environment:
+  &server-environment
+  - ASSET_HOST=splits.io
+  - AWS_ACCESS_KEY_ID
+  - AWS_REGION
+  - AWS_SECRET_KEY
+  - BUNDLE_WITHOUT=test:development
+  - DATABASE_URL
+  - ENABLE_ADS=1
+  - GOOGLE_CLIENT_ID
+  - GOOGLE_CLIENT_SECRET
+  - NEW_RELIC_LICENSE_KEY
+  - NODE_ENV=production
+  - PATREON_CLIENT_ID
+  - PATREON_CLIENT_SECRET
+  - PATREON_WEBHOOK_SECRET
+  - RACK_ENV=production
+  - RAILS_LOG_TO_STDOUT=true # Log to stdout so docker/docker-compose can take over logs
+  - RAILS_SERVE_STATIC_FILES=1
+  - RAILS_SKIP_ASSET_COMPILATION=false
+  - RAILS_SKIP_MIGRATIONS=false
+  - READ_ONLY_MODE=0
+  - REDIS_URL
+  - ROLLBAR_ACCESS_TOKEN
+  - S3_BUCKET
+  - SECRET_KEY_BASE
+  - SITE_TITLE=Splits.io
+  - SKYLIGHT_AUTHENTICATION
+  - SPLITSIO_CLIENT_ID
+  - SPLITSIO_CLIENT_SECRET
+  - TWITCH_CLIENT_ID
+  - TWITCH_CLIENT_SECRET
+x-logging:
+  &default-logging
+  driver: json-file
+  options:
+    max-size: 1m
+    max-file: "1"
+
 services:
   web:
-    image: web
     build:
       context: .
       dockerfile: Dockerfile
     command: bash -c "rm -f /app/tmp/pids/server.pid && yarn install && bundle exec rails db:migrate && bundle exec rails assets:precompile && bundle exec rails s -p 3000 -b '0.0.0.0'"
-    volumes:
-      - .:/app
+    environment: *server-environment
+    image: web
+    logging: *default-logging
     ports:
       - 3000:3000
-    environment: # Remember to add new vars both here and below in the worker container
-      - ASSET_HOST
-      - AWS_ACCESS_KEY_ID
-      - AWS_REGION
-      - AWS_SECRET_KEY
-      - BUNDLE_WITHOUT
-      - DATABASE_URL
-      - ENABLE_ADS
-      - GOOGLE_CLIENT_ID
-      - GOOGLE_CLIENT_SECRET
-      - NEW_RELIC_LICENSE_KEY
-      - NODE_ENV
-      - PATREON_CLIENT_ID
-      - PATREON_CLIENT_SECRET
-      - PATREON_WEBHOOK_SECRET
-      - RACK_ENV
-      - RAILS_SERVE_STATIC_FILES
-      - RAILS_SKIP_ASSET_COMPILATION
-      - RAILS_SKIP_MIGRATIONS
-      - READ_ONLY_MODE
-      - REDIS_URL
-      - ROLLBAR_ACCESS_TOKEN
-      - S3_BUCKET
-      - SECRET_KEY_BASE
-      - SITE_TITLE
-      - SKYLIGHT_AUTHENTICATION
-      - SPLITSIO_CLIENT_ID
-      - SPLITSIO_CLIENT_SECRET
-      - TWITCH_CLIENT_ID
-      - TWITCH_CLIENT_SECRET
+    volumes:
+      - .:/app
   worker:
-    image: worker
     build:
       context: .
       dockerfile: Dockerfile
     command: bash -c "rm -f /app/tmp/pids/delayed*.pid && ruby bin/delayed_job run -n 2"
+    environment: *server-environment
+    image: worker
+    logging: *default-logging
     ports: []
-    environment: # Remember to add new vars both here and above in the web container
-      - ASSET_HOST
-      - AWS_ACCESS_KEY_ID
-      - AWS_REGION
-      - AWS_SECRET_KEY
-      - BUNDLE_WITHOUT
-      - DATABASE_URL
-      - ENABLE_ADS
-      - GOOGLE_CLIENT_ID
-      - GOOGLE_CLIENT_SECRET
-      - NEW_RELIC_LICENSE_KEY
-      - NODE_ENV
-      - PATREON_CLIENT_ID
-      - PATREON_CLIENT_SECRET
-      - PATREON_WEBHOOK_SECRET
-      - RACK_ENV
-      - RAILS_SERVE_STATIC_FILES
-      - RAILS_SKIP_ASSET_COMPILATION
-      - RAILS_SKIP_MIGRATIONS
-      - READ_ONLY_MODE
-      - REDIS_URL
-      - ROLLBAR_ACCESS_TOKEN
-      - S3_BUCKET
-      - SECRET_KEY_BASE
-      - SITE_TITLE
-      - SKYLIGHT_AUTHENTICATION
-      - SPLITSIO_CLIENT_ID
-      - SPLITSIO_CLIENT_SECRET
-      - TWITCH_CLIENT_ID
-      - TWITCH_CLIENT_SECRET

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,97 +1,96 @@
-version: '2'
+version: '3.7'
+x-environment:
+  &server-environment
+  - AWS_REGION=local
+  - AWS_ACCESS_KEY_ID=beep
+  - AWS_SECRET_KEY=boop
+  - ENABLE_ADS=0
+  - GOOGLE_CLIENT_ID
+  - GOOGLE_CLIENT_SECRET
+  - NODE_ENV=development
+  - PATREON_CLIENT_ID
+  - PATREON_CLIENT_SECRET
+  - RAILS_LOG_TO_STDOUT=true # Log to stdout so docker/docker-compose can take over logs
+  - RAILS_ENV=development
+  - RAILS_ROOT="/app"
+  - READ_ONLY_MODE=0
+  - REDIS_URL="redis/0"
+  - S3_BUCKET=splits-io
+  - SITE_TITLE=Splits.io (Local)
+  - SPLITSIO_CLIENT_ID
+  - SPLITSIO_CLIENT_SECRET
+  - TWITCH_CLIENT_ID
+  - TWITCH_CLIENT_SECRET
+x-logging:
+  &default-logging
+  driver: json-file
+  options:
+    max-size: 1m
+    max-file: "1"
+
 services:
+  db:
+    image: postgres
+    logging: *default-logging
+    volumes:
+      - ./db/init.sql:/docker-entrypoint-initdb.d/10-init.sql
+  s3:
+    expose:
+      - "4569"
+    image: lphoward/fake-s3
+    logging: *default-logging
+    ports:
+      - 4569:4569
+  webpacker:
+    build: .
+    command: bash -c "yarn install && ruby bin/webpack-dev-server"
+    environment:
+      - SPLITSIO_CLIENT_ID
+    expose:
+      - "3035"
+    image: webpacker
+    logging: *default-logging
+    ports:
+      - 3035:3035
+    volumes:
+      - .:/app
   web:
-    image: web
     build:
       context: .
       dockerfile: Dockerfile
     command: bash -c "rm -f /app/tmp/pids/server.pid && bundle install && bundle exec rails db:migrate && bundle exec rails s -p 3000 -b '0.0.0.0'"
-    volumes:
-      - ./:/app
-    ports:
-      - 3000:3000
     depends_on:
       - db
       - s3
       - webpacker
       - worker
       - redis
+    environment: *server-environment
+    image: web
     links:
       - s3:s3.localhost
       - webpacker:webpacker.localhost
-    environment:
-      - AWS_REGION=local
-      - AWS_ACCESS_KEY_ID=beep
-      - AWS_SECRET_KEY=boop
-      - ENABLE_ADS=0
-      - NODE_ENV=development
-      - READ_ONLY_MODE=0
-      - REDIS_URL="redis/0"
-      - RAILS_ENV
-      - RAILS_ROOT="/app"
-      - S3_BUCKET=splits-io
-      - SITE_TITLE=Splits I/O (Local)
-      - GOOGLE_CLIENT_ID
-      - GOOGLE_CLIENT_SECRET
-      - PATREON_CLIENT_ID
-      - PATREON_CLIENT_SECRET
-      - SPLITSIO_CLIENT_ID
-      - TWITCH_CLIENT_ID
-      - TWITCH_CLIENT_SECRET
+    logging: *default-logging
+    ports:
+      - 3000:3000
     stdin_open: true
     tty: true
-  db:
-    image: postgres
     volumes:
-      - ./db/init.sql:/docker-entrypoint-initdb.d/10-init.sql
-  s3:
-    image: lphoward/fake-s3
-    ports:
-      - 4569:4569
-    expose:
-      - "4569"
-  webpacker:
-    image: webpacker
-    environment:
-      - SPLITSIO_CLIENT_ID
-    build: .
-    command: bash -c "yarn install && ruby bin/webpack-dev-server"
-    volumes:
-      - .:/app
-    ports:
-      - 3035:3035
-    expose:
-      - "3035"
+      - ./:/app
   worker:
-    image: worker
-    environment:
-      - AWS_REGION=local
-      - AWS_ACCESS_KEY_ID=beep
-      - AWS_SECRET_KEY=boop
-      - ENABLE_ADS=0
-      - NODE_ENV=development
-      - READ_ONLY_MODE=0
-      - REDIS_URL=redis/0
-      - RAILS_ENV
-      - RAILS_ROOT=/app
-      - S3_BUCKET=splits-io
-      - SITE_TITLE=Splits I/O (Local)
-      - GOOGLE_CLIENT_ID
-      - GOOGLE_CLIENT_SECRET
-      - PATREON_CLIENT_ID
-      - PATREON_CLIENT_SECRET
-      - SPLITSIO_CLIENT_ID
-      - TWITCH_CLIENT_ID
-      - TWITCH_CLIENT_SECRET
     build: .
     command: bash -c "rm -f /app/tmp/pids/delayed*.pid && bundle exec rake jobs:work"
-    ports: []
     depends_on:
       - db
       - s3
+    environment: *server-environment
+    image: worker
     links:
       - s3:s3.localhost
+    logging: *default-logging
+    ports: []
     stdin_open: true
     tty: true
   redis:
     image: redis
+    logging: *default-logging


### PR DESCRIPTION
Should fix our issue of log files growing infinitely big and crashing boxes.

1. Makes Rails log to its container's stdout so its logs can be managed by Docker
2. Adds log rotation to all containers
3. Also used new Docker Compose [extension fields][1] to clean up existing environment field
4. Also alphabetized compose files
5. Oh and also moved some non-secret env vars from on-box to the compose file

[1]: https://docs.docker.com/compose/compose-file/#extension-fields