### PR TITLE
Fix poisoned queues

### DIFF
--- a/app/jobs/broadcast_upload_job.rb
+++ b/app/jobs/broadcast_upload_job.rb
@@ -1,4 +1,5 @@
 class BroadcastUploadJob < ApplicationJob
+  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose-production.yml.
   queue_as :broadcast_upload
 
   def perform(run)

--- a/app/jobs/broadcast_upload_job.rb
+++ b/app/jobs/broadcast_upload_job.rb
@@ -1,5 +1,6 @@
 class BroadcastUploadJob < ApplicationJob
-  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose-production.yml.
+  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose.yml and
+  # docker-compose-production.yml.
   queue_as :broadcast_upload
 
   def perform(run)

--- a/app/jobs/discover_runner_job.rb
+++ b/app/jobs/discover_runner_job.rb
@@ -1,4 +1,5 @@
 class DiscoverRunnerJob < ApplicationJob
+  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose-production.yml.
   queue_as :discover_runner
 
   def perform(run)

--- a/app/jobs/discover_runner_job.rb
+++ b/app/jobs/discover_runner_job.rb
@@ -1,5 +1,6 @@
 class DiscoverRunnerJob < ApplicationJob
-  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose-production.yml.
+  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose.yml and
+  # docker-compose-production.yml.
   queue_as :discover_runner
 
   def perform(run)

--- a/app/jobs/highlight_cleanup_job.rb
+++ b/app/jobs/highlight_cleanup_job.rb
@@ -1,4 +1,5 @@
 class HighlightCleanupJob < ApplicationJob
+  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose-production.yml.
   queue_as :highlight_cleanup
 
   def perform(highlight_suggestion)

--- a/app/jobs/highlight_cleanup_job.rb
+++ b/app/jobs/highlight_cleanup_job.rb
@@ -1,5 +1,6 @@
 class HighlightCleanupJob < ApplicationJob
-  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose-production.yml.
+  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose.yml and
+  # docker-compose-production.yml.
   queue_as :highlight_cleanup
 
   def perform(highlight_suggestion)

--- a/app/jobs/refresh_game_job.rb
+++ b/app/jobs/refresh_game_job.rb
@@ -1,4 +1,5 @@
 class RefreshGameJob < ApplicationJob
+  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose-production.yml.
   queue_as :refresh_game
 
   def perform(game, category)

--- a/app/jobs/refresh_game_job.rb
+++ b/app/jobs/refresh_game_job.rb
@@ -1,5 +1,6 @@
 class RefreshGameJob < ApplicationJob
-  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose-production.yml.
+  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose.yml and
+  # docker-compose-production.yml.
   queue_as :refresh_game
 
   def perform(game, category)

--- a/app/jobs/sync_user_follows_job.rb
+++ b/app/jobs/sync_user_follows_job.rb
@@ -1,5 +1,6 @@
 class SyncUserFollowsJob < ApplicationJob
-  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose-production.yml.
+  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose.yml and
+  # docker-compose-production.yml.
   queue_as :sync_user_follows
 
   def perform(user, twitch_user)

--- a/app/jobs/sync_user_follows_job.rb
+++ b/app/jobs/sync_user_follows_job.rb
@@ -1,4 +1,5 @@
 class SyncUserFollowsJob < ApplicationJob
+  # Adding or deleting a job? Reflect the change in the QUEUES environment variable in docker-compose-production.yml.
   queue_as :sync_user_follows
 
   def perform(user, twitch_user)

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module SplitsIO
 
     config.action_controller.allow_forgery_protection = false
     config.active_job.queue_adapter = :delayed_job
+    config.active_job.queue_name_prefix = ENV['QUEUE_PREFIX']
 
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,6 @@ module SplitsIO
 
     config.action_controller.allow_forgery_protection = false
     config.active_job.queue_adapter = :delayed_job
-    config.active_job.queue_name_prefix = ENV['QUEUE_PREFIX']
 
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -15,6 +15,7 @@ x-environment:
   - PATREON_CLIENT_ID
   - PATREON_CLIENT_SECRET
   - PATREON_WEBHOOK_SECRET
+  - QUEUE_PREFIX
   - RACK_ENV=production
   - RAILS_LOG_TO_STDOUT=true # Log to stdout so docker/docker-compose can take over logs
   - RAILS_SERVE_STATIC_FILES=1

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -15,7 +15,7 @@ x-environment:
   - PATREON_CLIENT_ID
   - PATREON_CLIENT_SECRET
   - PATREON_WEBHOOK_SECRET
-  - QUEUE_PREFIX
+  - QUEUES=broadcast_upload,discover_runner,highlight_cleanup,refresh_game,sync_user_follows # keep this in sync with every job in app/jobs
   - RACK_ENV=production
   - RAILS_LOG_TO_STDOUT=true # Log to stdout so docker/docker-compose can take over logs
   - RAILS_SERVE_STATIC_FILES=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ x-environment:
   - NODE_ENV=development
   - PATREON_CLIENT_ID
   - PATREON_CLIENT_SECRET
+  - QUEUE_PREFIX=dev
   - RAILS_LOG_TO_STDOUT=true # Log to stdout so docker/docker-compose can take over logs
   - RAILS_ENV
   - RAILS_ROOT="/app"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ x-environment:
   - NODE_ENV=development
   - PATREON_CLIENT_ID
   - PATREON_CLIENT_SECRET
-  - QUEUE_PREFIX=dev
+  - QUEUES=broadcast_upload,discover_runner,highlight_cleanup,refresh_game,sync_user_follows # this is here only to make you also update docker-compose-production.yml
   - RAILS_LOG_TO_STDOUT=true # Log to stdout so docker/docker-compose can take over logs
   - RAILS_ENV
   - RAILS_ROOT="/app"


### PR DESCRIPTION
Fixes beta and production trying to process jobs enqueued by the other, which can make a box error indefinitely as it tries to run a job it doesn't know how to run.

Along with this I'll set QUEUE_PREFIX to `production` and `beta` on the respective boxes.