### PR TITLE
Fix double escaping in window titles

### DIFF
--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    title = content_for?(:title) ? "#{yield(:title)} - #{site_title}".html_safe : site_title
+    title = content_for?(:title) ? yield(:title) + " - #{site_title}" : site_title
     link href='//fonts.googleapis.com/css?family=Open+Sans|Anonymous+Pro' rel='stylesheet' type='text/css'
     link type='text/plain' rel='author' href='https://splits.io/humans.txt'
     meta name='viewport' content='width=device-width, initial-scale=1'

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    title = content_for?(:title) ? "#{yield(:title)} - #{site_title}" : site_title
+    title = content_for?(:title) ? "#{yield(:title)} - #{site_title}".html_safe : site_title
     link href='//fonts.googleapis.com/css?family=Open+Sans|Anonymous+Pro' rel='stylesheet' type='text/css'
     link type='text/plain' rel='author' href='https://splits.io/humans.txt'
     meta name='viewport' content='width=device-width, initial-scale=1'


### PR DESCRIPTION
When using `content_for`, the string is automatically escaped and converted to a `SafeBuffer`, whoever when using string concatenation this seems to be ignored, and another round of escaping is performed.

My original fix for this was just just escape the `Game`'s string value, but I feel like we would just hit the same issue down the line with some other resource.  So instead I opted to mark the title as `html_safe`, since the (potentially user) provided titles would already have been escaped, and we control the value of `site_title`.

Closes #570