### PR TITLE
Add Race.with_ends

### DIFF
--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -66,7 +66,7 @@ class Race < ApplicationRecord
         when bool_or(entries.finished_at is null and entries.forfeited_at is null) then null
         else greatest(max(entries.finished_at), max(entries.forfeited_at))
       end as ended_at
-    ').left_outer_joins(:entries).group(:id)
+    '.squish).left_outer_joins(:entries).group(:id)
   end
 
   def to_s

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -58,6 +58,17 @@ class Race < ApplicationRecord
     race
   end
 
+  # with_ends modifies the returned Races to have an ended_at field, which represents the timestamp at which the last
+  # entry finished or forfeited, or null if at least one entry has neither finished nor forfeited.
+  def self.with_ends
+    select('races.*,
+      case
+        when bool_or(entries.finished_at is null and entries.forfeited_at is null) then null
+        else greatest(max(entries.finished_at), max(entries.forfeited_at))
+      end as ended_at
+    ').left_outer_joins(:entries).group(:id)
+  end
+
   def to_s
     "#{game} #{category} #{title}".presence || 'Untitled race'
   end


### PR DESCRIPTION
Adds a `Race.with_ends` scope similar to `Segment.with_ends` and `SegmentHistory.with_ends`.

This method adds a computed field to the returned models called `ended_at` which contains the end time of the race, inherited from its slowest entry's finish or forfeit time (or null if at least one entry is still going).