### PR TITLE
Tweak race display behaviors

### DIFF
--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -33,14 +33,14 @@ class Race < ApplicationRecord
   end
 
   def self.finished
-    joins(:entries).where.not(entries: {finished_at: nil, forfeited_at: nil}).distinct
+    where.not(id: unfinished)
   end
 
   # unabandoned returns races that have had activity (e.g. creation, new entry, etc.) in the last hour
   # or have more than 2 entries. this includes races that have finished
   def self.unabandoned
     where('races.updated_at > ?', ABANDON_TIME.ago).or(
-      where(id: Entry.having('count(*) > 1').group(:race_id).select(:race_id))
+      where(id: Entry.where(ghost: false).having('count(*) > 1').group(:race_id).select(:race_id))
     )
   end
 

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -40,7 +40,7 @@ class Race < ApplicationRecord
   # or have more than 2 entries. this includes races that have finished
   def self.unabandoned
     where('races.updated_at > ?', ABANDON_TIME.ago).or(
-      where(id: Entry.where(ghost: false).having('count(*) > 1').group(:race_id).select(:race_id))
+      where(id: Entry.nonghosts.having('count(*) > 1').group(:race_id).select(:race_id))
     )
   end
 

--- a/app/views/games/categories/show.slim
+++ b/app/views/games/categories/show.slim
@@ -25,7 +25,7 @@
 .row.mx-2
   .col-md-6.mb-3: .card
     = render partial: 'shared/race_table', locals: { \
-      races: @game.races.finished.not_secret_visibility.order(created_at: :desc), \
+      races: @game.races.with_ends.finished.not_secret_visibility.order(ended_at: :desc), \
       active_races: @game.races.active.not_secret_visibility.order(created_at: :desc) \
     }
 

--- a/app/views/races/index.slim
+++ b/app/views/races/index.slim
@@ -6,7 +6,7 @@
 - if params[:historic] == '1'
   - races = Race.with_ends.finished.not_secret_visibility.order(ended_at: :desc)
 - else
-  - races = Race.active.not_secret_visibility.order('started_at ASC NULLS FIRST')
+  - races = Race.active.not_secret_visibility.order('started_at ASC NULLS FIRST, created_at DESC')
 
 article
   #vue-race.row

--- a/app/views/races/index.slim
+++ b/app/views/races/index.slim
@@ -4,7 +4,7 @@
     li.breadcrumb-item = link_to(site_title, root_path)
 
 - if params[:historic] == '1'
-  - races = Race.finished.not_secret_visibility.order(started_at: :desc)
+  - races = Race.with_ends.finished.not_secret_visibility.order(ended_at: :desc)
 - else
   - races = Race.active.not_secret_visibility.order('started_at ASC NULLS FIRST')
 

--- a/app/views/runs/index.slim
+++ b/app/views/runs/index.slim
@@ -27,7 +27,7 @@
     .row.mx-2
       .col-md-6.mb-3: .card.shadow
         = render partial: 'shared/race_table', locals: { \
-          races: current_user.races.finished.order(created_at: :desc), \
+          races: current_user.races.with_ends.finished.order(ended_at: :desc), \
           user: current_user, \
           active_races: current_user.races.unfinished, \
           description: 'My Races' \

--- a/app/views/shared/_race_table.slim
+++ b/app/views/shared/_race_table.slim
@@ -1,5 +1,5 @@
 - description ||= nil
-- cols ||= [:creator, :time, :entries, :name, :status, :created, :results]
+- cols ||= [:creator, :time, :entries, :name, :status, :finished, :results]
 - races = races.page(params[:page]).includes(:owner)
 - active_races ||= Race.none
 
@@ -25,8 +25,8 @@
             th width='100%' Title
           - if cols.include?(:status)
             th.align-right.nowrap Status
-          - if cols.include?(:created)
-            th.align-right.nowrap Created
+          - if cols.include?(:finished)
+            th.align-right.nowrap Finished
           - if cols.include?(:results)
             th.align-right.nowrap Results
       tbody
@@ -62,9 +62,13 @@
                     .text-danger Secret
                   - else
                     - raise # raise if we get an unexpected visibility
-            - if cols.include?(:created)
+            - if cols.include?(:finished)
               td.align-right.nowrap
-                 = render partial: 'shared/relative_time', locals: {time: race.created_at, ago: true}
+                - time = race.try(:ended_at)
+                - if time
+                  = render partial: 'shared/relative_time', locals: {time: race.ended_at, ago: true}
+                - else
+                  = '-'
             - if cols.include?(:results)
               td.align-right.text-primary.cursor-pointer data={toggle: 'collapse', target: "#accordion-#{race.id}"}
                 = icon('fas', 'list-ol')

--- a/app/views/users/show.slim
+++ b/app/views/users/show.slim
@@ -19,7 +19,7 @@
   .col-md-6.mb-3
     .card.shadow
       = render partial: 'shared/race_table', locals: { \
-        races: @user.races.finished.not_secret_visibility.order(created_at: :desc), \
+        races: @user.races.with_ends.finished.not_secret_visibility.order(ended_at: :desc), \
         user: @user, \
         active_races: @user.races.active.not_secret_visibility, \
         description: "#{@user}'s Races" \


### PR DESCRIPTION
Fixed `finished` scope selecting races with any entrant being done, only count real entrants for abandonment purposes, race table column created -> finished.