### PR TITLE
Don't allow decimals on the x-axis of the "Run Duration over Time" graph

### DIFF
--- a/app/javascript/charts/run_duration.js
+++ b/app/javascript/charts/run_duration.js
@@ -47,6 +47,7 @@ const buildRunDurationChart = function(runs, options = {}) {
       }
     },
     xAxis: {
+      allowDecimals: false,
       title: {text: 'Attempt Number'}
     },
     yAxis: {


### PR DESCRIPTION
This addresses #601 for `Run Duration over Time` graphs. The original issue mentioned the segment duration over time graph, as well, but fractional values on the x-axis were already disallowed there.