### PR TITLE
Ignore segments following a skipped split when calculating segment history stats

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -177,12 +177,12 @@ class Run < ApplicationRecord
   # instead of individually for each segment (N queries)
   def segment_history_stats(timing)
     stats = SegmentHistory.joins(segment: :run)
-              .joins(stats_join_additional_histories_query(timing))
-              .where(segment: {runs: {id: id}})
-              .where.not(Run.duration_type(timing) => [0, nil])
-              .where("segments_segment_histories.segment_number = 0 OR (other_histories.attempt_number = segment_histories.attempt_number AND other_histories.segment_number = segments_segment_histories.segment_number - 1)")
-              .group(:segment_id)
-              .select(stats_select_query(timing))
+                          .joins(stats_join_additional_histories_query(timing))
+                          .where(segment: {runs: {id: id}})
+                          .where.not(Run.duration_type(timing) => [0, nil])
+                          .where("segments_segment_histories.segment_number = 0 OR (other_histories.attempt_number = segment_histories.attempt_number AND other_histories.segment_number = segments_segment_histories.segment_number - 1)")
+                          .group(:segment_id)
+                          .select(stats_select_query(timing))
 
     h = {}
     stats.each do |stat|

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -176,18 +176,24 @@ class Run < ApplicationRecord
   # Calculate the various statistical information about each segments history once in the database for the whole run
   # instead of individually for each segment (N queries)
   def segment_history_stats(timing)
-    stats = segment_history_stats_query(timing)
+    stats = SegmentHistory.joins(segment: :run)
+              .joins(stats_join_additional_histories_query(timing))
+              .where(segment: {runs: {id: id}})
+              .where.not(Run.duration_type(timing) => [0, nil])
+              .where("segments_segment_histories.segment_number = 0 OR (other_histories.attempt_number = segment_histories.attempt_number AND other_histories.segment_number = segments_segment_histories.segment_number - 1)")
+              .group(:segment_id)
+              .select(stats_select_query(timing))
 
     h = {}
     stats.each do |stat|
-      h[stat['segment_id']] = {
-        standard_deviation: stat['standard_deviation'],
-        mean:               stat['mean'],
-        median:             stat['median'],
+      h[stat.segment_id] = {
+        standard_deviation: stat.standard_deviation,
+        mean:               stat.mean,
+        median:             stat.median,
         percentiles:        {
-          10 => stat['percentile10'],
-          90 => stat['percentile90'],
-          99 => stat['percentile99']
+          10 => stat.percentile10,
+          90 => stat.percentile90,
+          99 => stat.percentile99
         }
       }
     end
@@ -216,70 +222,63 @@ class Run < ApplicationRecord
 
   private
 
-  def segment_history_stats_query(timing)
-    sql = nil
+  def stats_join_additional_histories_query(timing)
     case timing
     when Run::REAL
-      sql = Run.sanitize_sql_array [%Q{
-      SELECT
-        segment_id,
-        STDDEV_POP(segment_histories.realtime_duration_ms) AS standard_deviation,
-        AVG(segment_histories.realtime_duration_ms) AS mean,
-        PERCENTILE_DISC(.5) WITHIN GROUP (ORDER BY segment_histories.realtime_duration_ms) AS median,
-        PERCENTILE_CONT(.1) WITHIN GROUP (ORDER BY segment_histories.realtime_duration_ms) AS percentile10,
-        PERCENTILE_CONT(.9) WITHIN GROUP (ORDER BY segment_histories.realtime_duration_ms) AS percentile90,
-        PERCENTILE_CONT(.99) WITHIN GROUP (ORDER BY segment_histories.realtime_duration_ms) AS percentile99
-      FROM segment_histories
-      INNER JOIN segments ON segments.id = segment_histories.segment_id
-      INNER JOIN runs ON runs.id = segments.run_id
-      LEFT JOIN (
-        SELECT segment_histories.id AS id, segment_histories.attempt_number AS attempt_number, segments.segment_number as segment_number
-        FROM segment_histories
-        INNER JOIN segments ON segments.id = segment_histories.segment_id
-        WHERE segments.run_id = :run_id
-        AND NOT ((segment_histories.realtime_duration_ms = 0 OR segment_histories.realtime_duration_ms IS NULL))
-      ) AS other_histories ON other_histories.attempt_number = segment_histories.attempt_number AND other_histories.segment_number = segments.segment_number - 1
-      WHERE runs.id = :run_id
-        AND NOT ((segment_histories.realtime_duration_ms = 0 OR segment_histories.realtime_duration_ms IS NULL))
-        AND (segments.segment_number = 0 OR
-          (other_histories.attempt_number = segment_histories.attempt_number
-          AND other_histories.segment_number = segments.segment_number - 1)
-        )
-      GROUP BY segment_id
-    }.squish, run_id: id]
-
+      Run.sanitize_sql_array [%Q{
+        LEFT JOIN (
+          SELECT segment_histories.id AS id,
+            segment_histories.attempt_number AS attempt_number,
+            segments.segment_number as segment_number
+          FROM segment_histories
+          INNER JOIN segments ON segments.id = segment_histories.segment_id
+            WHERE segments.run_id = :run_id
+            AND NOT ((segment_histories.realtime_duration_ms = 0
+              OR segment_histories.realtime_duration_ms IS NULL))
+        ) AS other_histories ON
+          other_histories.attempt_number = segment_histories.attempt_number
+          AND other_histories.segment_number = segments_segment_histories.segment_number - 1}.squish, run_id: id]
     when Run::GAME
-      sql = Run.sanitize_sql_array [%Q{
-      SELECT
-        segment_id,
-        STDDEV_POP(segment_histories.gametime_duration_ms) AS standard_deviation,
-        AVG(segment_histories.gametime_duration_ms) AS mean,
-        PERCENTILE_DISC(.5) WITHIN GROUP (ORDER BY segment_histories.gametime_duration_ms) AS median,
-        PERCENTILE_CONT(.1) WITHIN GROUP (ORDER BY segment_histories.gametime_duration_ms) AS percentile10,
-        PERCENTILE_CONT(.9) WITHIN GROUP (ORDER BY segment_histories.gametime_duration_ms) AS percentile90,
-        PERCENTILE_CONT(.99) WITHIN GROUP (ORDER BY segment_histories.gametime_duration_ms) AS percentile99
-      FROM segment_histories
-      INNER JOIN segments ON segments.id = segment_histories.segment_id
-      INNER JOIN runs ON runs.id = segments.run_id
-      LEFT JOIN (
-        SELECT segment_histories.id AS id, segment_histories.attempt_number AS attempt_number, segments.segment_number as segment_number
-        FROM segment_histories
-        INNER JOIN segments ON segments.id = segment_histories.segment_id
-        WHERE segments.run_id = :run_id
-        AND NOT ((segment_histories.gametime_duration_ms = 0 OR segment_histories.gametime_duration_ms IS NULL))
-      ) AS other_histories ON other_histories.attempt_number = segment_histories.attempt_number AND other_histories.segment_number = segments.segment_number - 1
-      WHERE runs.id = :run_id
-        AND NOT ((segment_histories.gametime_duration_ms = 0 OR segment_histories.gametime_duration_ms IS NULL))
-        AND (segments.segment_number = 0 OR
-          (other_histories.attempt_number = segment_histories.attempt_number
-          AND other_histories.segment_number = segments.segment_number - 1)
-        )
-      GROUP BY segment_id
-    }.squish, run_id: id]
+      Run.sanitize_sql_array [%Q{
+        LEFT JOIN (
+          SELECT segment_histories.id AS id,
+            segment_histories.attempt_number AS attempt_number,
+            segments.segment_number as segment_number
+          FROM segment_histories
+          INNER JOIN segments ON segments.id = segment_histories.segment_id
+            WHERE segments.run_id = :run_id
+            AND NOT ((segment_histories.gametime_duration_ms = 0
+              OR segment_histories.gametime_duration_ms IS NULL))
+        ) AS other_histories ON
+          other_histories.attempt_number = segment_histories.attempt_number
+          AND other_histories.segment_number = segments_segment_histories.segment_number - 1}.squish, run_id: id]
     else
       raise 'Unsupported timing'
     end
+  end
 
-    ActiveRecord::Base.connection.exec_query(sql).to_a
+  def stats_select_query(timing)
+    case timing
+    when Run::REAL
+      'segment_id,
+      STDDEV_POP(segment_histories.realtime_duration_ms) AS standard_deviation,
+      AVG(segment_histories.realtime_duration_ms) AS mean,
+      PERCENTILE_DISC(.5) WITHIN GROUP (ORDER BY segment_histories.realtime_duration_ms) AS median,
+      PERCENTILE_CONT(.1) WITHIN GROUP (ORDER BY segment_histories.realtime_duration_ms) AS percentile10,
+      PERCENTILE_CONT(.9) WITHIN GROUP (ORDER BY segment_histories.realtime_duration_ms) AS percentile90,
+      PERCENTILE_CONT(.99) WITHIN GROUP (ORDER BY segment_histories.realtime_duration_ms) AS percentile99
+      '.squish
+    when Run::GAME
+      'segment_id,
+      STDDEV_POP(segment_histories.gametime_duration_ms) AS standard_deviation,
+      AVG(segment_histories.gametime_duration_ms) AS mean,
+      PERCENTILE_DISC(.5) WITHIN GROUP (ORDER BY segment_histories.gametime_duration_ms) AS median,
+      PERCENTILE_CONT(.1) WITHIN GROUP (ORDER BY segment_histories.gametime_duration_ms) AS percentile10,
+      PERCENTILE_CONT(.9) WITHIN GROUP (ORDER BY segment_histories.gametime_duration_ms) AS percentile90,
+      PERCENTILE_CONT(.99) WITHIN GROUP (ORDER BY segment_histories.gametime_duration_ms) AS percentile99
+      '.squish
+    else
+      raise 'Unsupported timing'
+    end
   end
 end

--- a/app/models/segment_history.rb
+++ b/app/models/segment_history.rb
@@ -22,6 +22,41 @@ class SegmentHistory < ApplicationRecord
     '.squish)
   end
 
+  def self.without_statistically_invalid_histories_for_run(run, timing)
+    case timing
+    when Run::REAL
+      joins(SegmentHistory.sanitize_sql_array [%Q{
+        LEFT JOIN (
+          SELECT segment_histories.id AS id,
+            segment_histories.attempt_number AS attempt_number,
+            segments.segment_number as segment_number
+          FROM segment_histories
+          INNER JOIN segments ON segments.id = segment_histories.segment_id
+            WHERE segments.run_id = :run_id
+            AND NOT ((segment_histories.realtime_duration_ms = 0
+              OR segment_histories.realtime_duration_ms IS NULL))
+        ) AS other_histories ON
+          other_histories.attempt_number = segment_histories.attempt_number
+          AND other_histories.segment_number = segments_segment_histories.segment_number - 1}.squish, run_id: run.id])
+    when Run::GAME
+      joins(SegmentHistory.sanitize_sql_array [%Q{
+        LEFT JOIN (
+          SELECT segment_histories.id AS id,
+            segment_histories.attempt_number AS attempt_number,
+            segments.segment_number as segment_number
+          FROM segment_histories
+          INNER JOIN segments ON segments.id = segment_histories.segment_id
+            WHERE segments.run_id = :run_id
+            AND NOT ((segment_histories.gametime_duration_ms = 0
+              OR segment_histories.gametime_duration_ms IS NULL))
+        ) AS other_histories ON
+          other_histories.attempt_number = segment_histories.attempt_number
+          AND other_histories.segment_number = segments_segment_histories.segment_number - 1}.squish, run_id: run.id])
+    else
+      raise 'Unsupported timing'
+    end
+  end
+
   # duration returns the duration of this segment.
   def duration(timing)
     case timing

--- a/spec/factories/run_factory.rb
+++ b/spec/factories/run_factory.rb
@@ -20,7 +20,10 @@ FactoryBot.define do
     compare_object:           {filename: 'compare_object.lss'},
 
     # specific-content runs
-    with_segments_bests:       {filename: 'with_segments_bests.lss'}
+    with_segments_bests:      {filename: 'with_segments_bests.lss'},
+
+    # skipped splits
+    skipped_splits:           {filename: 'livesplit_skipped_splits.lss'},
   }
 
   test_files.each do |_factory_name, file|

--- a/spec/factories/run_files/livesplit_skipped_splits.lss
+++ b/spec/factories/run_files/livesplit_skipped_splits.lss
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Run version="1.6.0">
+  <GameIcon />
+  <GameName>NES Open Tournament Golf</GameName>
+  <CategoryName>US Course</CategoryName>
+  <Metadata>
+    <Run id="" />
+    <Platform usesEmulator="False">
+    </Platform>
+    <Region>
+    </Region>
+    <Variables />
+  </Metadata>
+  <Offset>00:00:00</Offset>
+  <AttemptCount>3</AttemptCount>
+  <AttemptHistory>
+    <Attempt id="1" started="08/30/2015 19:18:51" isStartedSynced="True" ended="08/30/2015 20:18:51" isEndedSynced="True">
+      <RealTime>01:00:00.0000000</RealTime>
+    </Attempt>
+    <Attempt id="2" started="08/31/2015 19:36:33" isStartedSynced="True" ended="08/31/2015 20:26:33" isEndedSynced="True">
+      <RealTime>00:50:00.0000000</RealTime>
+    </Attempt>
+    <Attempt id="3" started="09/01/2015 19:57:51" isStartedSynced="True" ended="09/01/2015 20:37:51" isEndedSynced="True">
+      <RealTime>00:40:00.0000000</RealTime>
+    </Attempt>
+  </AttemptHistory>
+  <Segments>
+    <Segment>
+      <Name>Segment 1</Name>
+      <Icon />
+      <SegmentHistory>
+        <Time id="1">
+          <RealTime>00:03:00.0000000</RealTime>
+        </Time>
+        <Time id="2">
+          <RealTime>00:02:00.0000000</RealTime>
+        </Time>
+        <Time id="3">
+          <RealTime>00:01:00.0000000</RealTime>
+        </Time>
+      </SegmentHistory>
+    </Segment>
+    <Segment>
+      <Name>Segment 2</Name>
+      <Icon />
+      <SegmentHistory>
+        <Time id="1" />
+        <Time id="2">
+          <RealTime>00:40:00.0000000</RealTime>
+        </Time>
+        <Time id="3">
+          <RealTime>00:25:00.0000000</RealTime>
+        </Time>
+      </SegmentHistory>
+    </Segment>
+    <Segment>
+      <Name>Segment 3</Name>
+      <Icon />
+      <SegmentHistory>
+        <Time id="1">
+          <RealTime>00:57:00.0000000</RealTime>
+        </Time>
+        <Time id="2">
+          <RealTime>00:08:00.0000000</RealTime>
+        </Time>
+        <Time id="3">
+          <RealTime>00:14:00.0000000</RealTime>
+        </Time>
+      </SegmentHistory>
+    </Segment>
+  </Segments>
+  <AutoSplitterSettings />
+</Run>

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -589,4 +589,39 @@ describe Run, type: :model do
       expect(run.total_playtime_ms).to eq 8_589_280
     end
   end
+
+  context 'skipped splits stats' do
+    let(:run) do
+      r = FactoryBot.create(:skipped_splits_run)
+      r.parse_into_db
+      r.reload
+      r
+    end
+
+    it 'has the correct stats' do
+      stats = run.segment_history_stats(Run::REAL)
+      ids = run.segments.order(:segment_number).map(&:id)
+
+      expect(stats[ids[0]][:standard_deviation].to_f).to eq 48989.79485566
+      expect(stats[ids[0]][:mean].to_f).to eq 120000
+      expect(stats[ids[0]][:median].to_f).to eq 120000
+      expect(stats[ids[0]][:percentiles][10].to_f).to eq 72000
+      expect(stats[ids[0]][:percentiles][90].to_f).to eq 168000
+      expect(stats[ids[0]][:percentiles][99].to_f).to eq 178800
+
+      expect(stats[ids[1]][:standard_deviation].to_f).to eq 450000
+      expect(stats[ids[1]][:mean].to_f).to eq 1950000
+      expect(stats[ids[1]][:median].to_f).to eq 1500000
+      expect(stats[ids[1]][:percentiles][10].to_f).to eq 1590000
+      expect(stats[ids[1]][:percentiles][90].to_f).to eq 2310000
+      expect(stats[ids[1]][:percentiles][99].to_f).to eq 2391000
+
+      expect(stats[ids[2]][:standard_deviation].to_f).to eq 180000
+      expect(stats[ids[2]][:mean].to_f).to eq 660000
+      expect(stats[ids[2]][:median].to_f).to eq 480000
+      expect(stats[ids[2]][:percentiles][10].to_f).to eq 516000
+      expect(stats[ids[2]][:percentiles][90].to_f).to eq 804000
+      expect(stats[ids[2]][:percentiles][99].to_f).to eq 836400
+    end
+  end
 end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -602,21 +602,24 @@ describe Run, type: :model do
       stats = run.segment_history_stats(Run::REAL)
       ids = run.segments.order(:segment_number).map(&:id)
 
-      expect(stats[ids[0]][:standard_deviation].to_f).to eq 48989.79485566
+      expect(stats[ids[0]][:standard_deviation].to_f).to be_within(1)
+                                                           .of(48989)
       expect(stats[ids[0]][:mean].to_f).to eq 120000
       expect(stats[ids[0]][:median].to_f).to eq 120000
       expect(stats[ids[0]][:percentiles][10].to_f).to eq 72000
       expect(stats[ids[0]][:percentiles][90].to_f).to eq 168000
       expect(stats[ids[0]][:percentiles][99].to_f).to eq 178800
 
-      expect(stats[ids[1]][:standard_deviation].to_f).to eq 450000
+      expect(stats[ids[1]][:standard_deviation].to_f).to be_within(1)
+                                                           .of(450000)
       expect(stats[ids[1]][:mean].to_f).to eq 1950000
       expect(stats[ids[1]][:median].to_f).to eq 1500000
       expect(stats[ids[1]][:percentiles][10].to_f).to eq 1590000
       expect(stats[ids[1]][:percentiles][90].to_f).to eq 2310000
       expect(stats[ids[1]][:percentiles][99].to_f).to eq 2391000
 
-      expect(stats[ids[2]][:standard_deviation].to_f).to eq 180000
+      expect(stats[ids[2]][:standard_deviation].to_f).to be_within(1)
+                                                           .of(180000)
       expect(stats[ids[2]][:mean].to_f).to eq 660000
       expect(stats[ids[2]][:median].to_f).to eq 480000
       expect(stats[ids[2]][:percentiles][10].to_f).to eq 516000

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -603,28 +603,28 @@ describe Run, type: :model do
       ids = run.segments.order(:segment_number).map(&:id)
 
       expect(stats[ids[0]][:standard_deviation].to_f).to be_within(1)
-                                                           .of(48989)
-      expect(stats[ids[0]][:mean].to_f).to eq 120000
-      expect(stats[ids[0]][:median].to_f).to eq 120000
-      expect(stats[ids[0]][:percentiles][10].to_f).to eq 72000
-      expect(stats[ids[0]][:percentiles][90].to_f).to eq 168000
-      expect(stats[ids[0]][:percentiles][99].to_f).to eq 178800
+                                                           .of(48_989)
+      expect(stats[ids[0]][:mean].to_f).to eq 120_000
+      expect(stats[ids[0]][:median].to_f).to eq 120_000
+      expect(stats[ids[0]][:percentiles][10].to_f).to eq 72_000
+      expect(stats[ids[0]][:percentiles][90].to_f).to eq 168_000
+      expect(stats[ids[0]][:percentiles][99].to_f).to eq 178_800
 
       expect(stats[ids[1]][:standard_deviation].to_f).to be_within(1)
-                                                           .of(450000)
-      expect(stats[ids[1]][:mean].to_f).to eq 1950000
-      expect(stats[ids[1]][:median].to_f).to eq 1500000
-      expect(stats[ids[1]][:percentiles][10].to_f).to eq 1590000
-      expect(stats[ids[1]][:percentiles][90].to_f).to eq 2310000
-      expect(stats[ids[1]][:percentiles][99].to_f).to eq 2391000
+                                                           .of(450_000)
+      expect(stats[ids[1]][:mean].to_f).to eq 1_950_000
+      expect(stats[ids[1]][:median].to_f).to eq 1_500_000
+      expect(stats[ids[1]][:percentiles][10].to_f).to eq 1_590_000
+      expect(stats[ids[1]][:percentiles][90].to_f).to eq 2_310_000
+      expect(stats[ids[1]][:percentiles][99].to_f).to eq 2_391_000
 
       expect(stats[ids[2]][:standard_deviation].to_f).to be_within(1)
-                                                           .of(180000)
-      expect(stats[ids[2]][:mean].to_f).to eq 660000
-      expect(stats[ids[2]][:median].to_f).to eq 480000
-      expect(stats[ids[2]][:percentiles][10].to_f).to eq 516000
-      expect(stats[ids[2]][:percentiles][90].to_f).to eq 804000
-      expect(stats[ids[2]][:percentiles][99].to_f).to eq 836400
+                                                           .of(180_000)
+      expect(stats[ids[2]][:mean].to_f).to eq 660_000
+      expect(stats[ids[2]][:median].to_f).to eq 480_000
+      expect(stats[ids[2]][:percentiles][10].to_f).to eq 516_000
+      expect(stats[ids[2]][:percentiles][90].to_f).to eq 804_000
+      expect(stats[ids[2]][:percentiles][99].to_f).to eq 836_400
     end
   end
 end


### PR DESCRIPTION
Closes #562.

When calculating segment_history_stats, skipped splits would cause time to accumulate in later splits.

I didn't want to turn this into a direct SQL query, but ActiveRecord was mishandling the result of the query if compiled using ActiveRecord notation for most of it, despite that fact it was generating identical raw SQL.

    SegmentHistory.joins(segment: :run)
      .joins(%Q{LEFT JOIN (SELECT segment_histories.id AS id, segment_histories.attempt_number AS attempt_number, segments.segment_number as segment_number FROM segment_histories INNER JOIN "segments" ON "segments"."id" = "segment_histories"."segment_id" WHERE segments.run_id = #{id} AND NOT (("segment_histories"."realtime_duration_ms" = 0 OR "segment_histories"."realtime_duration_ms" IS NULL))) AS other_histories ON other_histories.attempt_number = segment_histories.attempt_number AND other_histories.segment_number = segments_segment_histories.segment_number - 1})
      .where(segment: {runs: {id: id}})
      .where.not(Run.duration_type(timing) => [0, nil])
      .where("segments_segment_histories.segment_number = 0 OR (other_histories.attempt_number = segment_histories.attempt_number AND (other_histories.segment_number = segments_segment_histories.segment_number - 1)")
      .group(:segment_id)
      .select(stats_select_query(timing))

Because of that, I just wrote the SQL manually and executed it.

I'm leaving the PR as a draft for now looking for feedback on the solution and while I look at trying to get some tests written that would fail under the old method and pass with the new query.