### PR TITLE
Ignore splits after a skipped split in some charts

### DIFF
--- a/app/javascript/charts/box_plot.js
+++ b/app/javascript/charts/box_plot.js
@@ -45,7 +45,7 @@ const buildBoxPlot = (runs, options = {}) => {
     },
     series: runs.map(run => ({
       data: run.segments.map(segment => {
-        const histories = segment.histories.map(attempt => attempt[duration]).filter(duration => duration > 0)
+        const histories = segment.filteredHistories.map(attempt => attempt[duration])
         const q1 = quantile(histories, .25)
         const q3 = quantile(histories, .75)
         const iqr = q3 - q1 // interquartile range, used for finding outliers (below)

--- a/app/javascript/charts/segment.js
+++ b/app/javascript/charts/segment.js
@@ -32,22 +32,8 @@ const buildSegmentChart = function(runs, options) {
     // Start mean info collection
     time = 0
     let counter = 0
-    if (segment.histories.length !== 0) {
-      segment.histories.forEach((attempt) => {
-        if (attempt[duration] === 0) {
-          // Reject attempts that have no duration (skipped splits)
-          return
-        } else if (run.segments[i - 1] !== undefined) {
-          const prevSegAttempt = run.segments[i - 1].histories.find((prevAttempt) => {
-            // Find the previous splits attempt for this same attempt id to make sure it wasn't skipped
-            return prevAttempt.attempt_number === attempt.attempt_number
-          })
-          if (prevSegAttempt !== undefined && prevSegAttempt[duration] === 0) {
-            // Reject the first split after a series of skipped splits to prevent data pollution
-            return
-          }
-        }
-
+    if ((segment.filteredHistories || segment.histories).length !== 0) {
+      (segment.filteredHistories || segment.histories).forEach((attempt) => {
         time += attempt[duration]
         counter++
       })

--- a/app/javascript/charts/segment_duration.js
+++ b/app/javascript/charts/segment_duration.js
@@ -31,7 +31,7 @@ const buildSegmentDurationChart = function(timing, runs, segments, options = {})
     },
     series: segments.map((segment, i) => ({
       name: `${(runs[i].runners[0] || {name: '???'}).name}'s ${segment.name}`,
-      data: segment.histories.filter(attempt => attempt[duration] > 0).map(attempt => {
+      data: (segment.filteredHistories || segment.histories).map(attempt => {
         return [`Attempt #${attempt.attempt_number}`, attempt[duration]]
       }),
       pointStart: 1


### PR DESCRIPTION
Closes #527 

This takes the code from `segment.js` that ignored splits following a skipped split and moves it higher up so that all charts can use it easily. The only real complication came from the augmented object hierarchy not being mirrored in the example object used for the landing page. For the time being, I just used the original segment histories as a fallback if the filtered histories were completely missing (as they are on the landing page).

Reset Rate on Individual Segment Stats and Resets Per Split both want the unfiltered histories, so we can't just only use the filtered histories.