### PR TITLE
Improve split timeline comparisons

### DIFF
--- a/app/assets/stylesheets/timeline.sass
+++ b/app/assets/stylesheets/timeline.sass
@@ -56,6 +56,7 @@
 .gold.timeline
   background: $green
   font-size: .5em
+  position: relative
 
 .gold-split
   background-color: $light-black
@@ -66,8 +67,14 @@
   padding: 0
   width: .45em
 
+.timeline-animation
+  left: 0px
+  transition-property: left
+  transition-duration: 0.2s
+
 .timeline-background
   background: repeating-linear-gradient(-45deg, rgba(255, 255, 255, .1), rgba(255, 255, 255, .1), 6px, rgba(0, 0, 0, .1) 6px, rgba(0, 0, 0, .1) 12px)
+  position: relative
 
 .video-progress-line
   height: 6em

--- a/app/assets/stylesheets/timeline.sass
+++ b/app/assets/stylesheets/timeline.sass
@@ -69,8 +69,8 @@
 
 .timeline-animation
   left: 0px
-  transition-property: left
   transition-duration: 0.2s
+  transition-property: left
 
 .timeline-background
   background: repeating-linear-gradient(-45deg, rgba(255, 255, 255, .1), rgba(255, 255, 255, .1), 6px, rgba(0, 0, 0, .1) 6px, rgba(0, 0, 0, .1) 12px)

--- a/app/javascript/timeline.js
+++ b/app/javascript/timeline.js
@@ -1,24 +1,89 @@
-document.addEventListener('mouseover', event => {
-  const segment = event.target.closest('.split')
-  if (segment === null) {
-    return
-  }
+let currentTimelineRunId = ''
+const timelineMouseOverTimers = {}
+const timelineMouseOutTimers = {}
 
+const mouseOverSegment = (segment) => {
   const run_id = segment.dataset.run_id
+  currentTimelineRunId = run_id
   const segment_number = segment.dataset.segment_number
+  const timerKey = `${run_id}-${segment_number}`
+  timelineMouseOverTimers[timerKey] = undefined
+
   const query = `.segment-inspect[data-run_id='${run_id}'][data-segment_number='${segment_number}']`
-  const leftEdge = segment.offsetLeft
   document.querySelector(query).style.visibility = 'visible'
-  document.querySelectorAll(`.split[data-segment_number='${segment_number}']:not([data-run_id='${run_id}'])`).forEach((el) => {
+
+  const leftEdge = segment.offsetLeft
+  const otherTimelinesQuery = `.split[data-segment_number='${segment_number}']:not([data-run_id='${run_id}'])`
+  document.querySelectorAll(otherTimelinesQuery).forEach((el) => {
     const otherLeftEdge = el.offsetLeft
     const timeline = el.closest('.timeline-background')
     const goldTimeline = timeline.parentElement.querySelector('.gold.timeline')
+    const videoProgressLine = document.getElementById(`video-progress-line-${el.dataset.run_id}`)
     const offset = leftEdge - otherLeftEdge
     timeline.style.position = 'relative'
     timeline.style.left = `${offset}px`
     goldTimeline.style.position = 'relative'
     goldTimeline.style.left = `${offset}px`
+    if (videoProgressLine !== null) {
+      videoProgressLine.style.left = `${offset}px`
+    }
   })
+}
+
+const mouseOutSegment = (segment) => {
+  const run_id = segment.dataset.run_id
+  const segment_number = segment.dataset.segment_number
+  const timerKey = `${run_id}-${segment_number}`
+  timelineMouseOutTimers[timerKey] = undefined
+
+  const query = `.segment-inspect[data-run_id='${run_id}'][data-segment_number='${segment_number}']`
+  document.querySelector(query).style.visibility = 'hidden'
+
+  if (currentTimelineRunId === run_id) {
+    // We are moving between segments on the same timeline, so don't shift
+    // the other timelines back to their origins as they'll just get moved
+    // to a new position momentarily and there will be an annoying visual jump
+    return
+  }
+
+  const otherTimelinesQuery = `.split[data-segment_number='${segment_number}']:not([data-run_id='${run_id}'])`
+  document.querySelectorAll(otherTimelinesQuery).forEach((el) => {
+    const timeline = el.closest('.timeline-background')
+    const goldTimeline = timeline.parentElement.querySelector('.gold.timeline')
+    const videoProgressLine = document.getElementById(`video-progress-line-${el.dataset.run_id}`)
+    timeline.style.position = ""
+    timeline.style.left = ""
+    goldTimeline.style.position = ""
+    goldTimeline.style.left = ""
+    if (videoProgressLine !== null) {
+      videoProgressLine.style.left = ""
+    }
+  })
+}
+
+document.addEventListener('mouseover', event => {
+  const segment = event.target.closest('.split')
+  if (segment === null) {
+    // We're no longer over a timeline, so there is no currentTimelineRunId
+    currentTimelineRunId = ''
+    return
+  }
+
+  const run_id = segment.dataset.run_id
+  const segment_number = segment.dataset.segment_number
+  const timerKey = `${run_id}-${segment_number}`
+  if (timelineMouseOutTimers[timerKey] !== undefined) {
+    // We moved off of this segment and then back on
+    // So don't do the mouseout stuff since our mouse is no longer out
+    clearTimeout(timelineMouseOutTimers[timerKey])
+    timelineMouseOutTimers[timerKey] = undefined
+  }
+  if (timelineMouseOverTimers[timerKey] !== undefined) {
+    // We already have a timer running for thsi segment; don't start another
+    return
+  }
+
+  timelineMouseOverTimers[timerKey] = setTimeout(mouseOverSegment.bind(null, segment), 100)
 })
 
 document.addEventListener('mouseout', event => {
@@ -29,14 +94,19 @@ document.addEventListener('mouseout', event => {
 
   const run_id = segment.dataset.run_id
   const segment_number = segment.dataset.segment_number
-  const query = `.segment-inspect[data-run_id='${run_id}'][data-segment_number='${segment_number}']`
-  document.querySelector(query).style.visibility = 'hidden'
-  document.querySelectorAll(`.split[data-segment_number='${segment_number}']:not([data-run_id='${run_id}'])`).forEach((el) => {
-    const timeline = el.closest('.timeline-background')
-    const goldTimeline = timeline.parentElement.querySelector('.gold.timeline')
-    timeline.style.position = ""
-    timeline.style.left = ""
-    goldTimeline.style.position = ""
-    goldTimeline.style.left = ""
-  })
+  const timerKey = `${run_id}-${segment_number}`
+  if (timelineMouseOverTimers[timerKey] !== undefined) {
+    // We just moved our mouse over this segment and then out of it
+    // So we don't want to actually do mouseover stuff for it
+    // since we're no longer over it
+    clearTimeout(timelineMouseOverTimers[timerKey])
+    timelineMouseOverTimers[timerKey] = undefined
+  }
+
+  if (timelineMouseOutTimers[timerKey] !== undefined) {
+    // We already have a timer running for thsi segment; don't start another
+    return
+  }
+
+  timelineMouseOutTimers[timerKey] = setTimeout(mouseOutSegment.bind(null, segment), 100)
 })

--- a/app/javascript/timeline.js
+++ b/app/javascript/timeline.js
@@ -7,7 +7,18 @@ document.addEventListener('mouseover', event => {
   const run_id = segment.dataset.run_id
   const segment_number = segment.dataset.segment_number
   const query = `.segment-inspect[data-run_id='${run_id}'][data-segment_number='${segment_number}']`
+  const leftEdge = segment.offsetLeft
   document.querySelector(query).style.visibility = 'visible'
+  document.querySelectorAll(`.split[data-segment_number='${segment_number}']:not([data-run_id='${run_id}'])`).forEach((el) => {
+    const otherLeftEdge = el.offsetLeft
+    const timeline = el.closest('.timeline-background')
+    const goldTimeline = timeline.parentElement.querySelector('.gold.timeline')
+    const offset = leftEdge - otherLeftEdge
+    timeline.style.position = 'relative'
+    timeline.style.left = `${offset}px`
+    goldTimeline.style.position = 'relative'
+    goldTimeline.style.left = `${offset}px`
+  })
 })
 
 document.addEventListener('mouseout', event => {
@@ -20,4 +31,12 @@ document.addEventListener('mouseout', event => {
   const segment_number = segment.dataset.segment_number
   const query = `.segment-inspect[data-run_id='${run_id}'][data-segment_number='${segment_number}']`
   document.querySelector(query).style.visibility = 'hidden'
+  document.querySelectorAll(`.split[data-segment_number='${segment_number}']:not([data-run_id='${run_id}'])`).forEach((el) => {
+    const timeline = el.closest('.timeline-background')
+    const goldTimeline = timeline.parentElement.querySelector('.gold.timeline')
+    timeline.style.position = ""
+    timeline.style.left = ""
+    goldTimeline.style.position = ""
+    goldTimeline.style.left = ""
+  })
 })

--- a/app/javascript/timeline.js
+++ b/app/javascript/timeline.js
@@ -8,9 +8,6 @@ const mouseOverSegment = (segment) => {
   const timerKey = `${run_id}-${segment_number}`
   timelineMouseOverTimers[timerKey] = undefined
 
-  const query = `.segment-inspect[data-run_id='${run_id}'][data-segment_number='${segment_number}']`
-  document.querySelector(query).style.visibility = 'visible'
-
   const leftEdge = segment.offsetLeft
   const otherTimelinesQuery = `.split[data-segment_number='${segment_number}']:not([data-run_id='${run_id}'])`
   document.querySelectorAll(otherTimelinesQuery).forEach((el) => {
@@ -32,9 +29,6 @@ const mouseOutSegment = (segment) => {
   const segment_number = segment.dataset.segment_number
   const timerKey = `${run_id}-${segment_number}`
   timelineMouseOutTimers[timerKey] = undefined
-
-  const query = `.segment-inspect[data-run_id='${run_id}'][data-segment_number='${segment_number}']`
-  document.querySelector(query).style.visibility = 'hidden'
 
   if (currentTimelineRunId === run_id) {
     // We are moving between segments on the same timeline, so don't shift
@@ -67,6 +61,12 @@ document.addEventListener('mouseover', event => {
   currentTimelineRunId = run_id
   const segment_number = segment.dataset.segment_number
   const timerKey = `${run_id}-${segment_number}`
+
+  // Go aheand and show the timeline inspector
+  const query = `.segment-inspect[data-run_id='${run_id}'][data-segment_number='${segment_number}']`
+  document.querySelector(query).style.visibility = 'visible'
+
+
   if (timelineMouseOutTimers[timerKey] !== undefined) {
     // We moved off of this segment and then back on
     // So don't do the mouseout stuff since our mouse is no longer out
@@ -89,6 +89,11 @@ document.addEventListener('mouseout', event => {
 
   const run_id = segment.dataset.run_id
   const segment_number = segment.dataset.segment_number
+
+  // Go ahead and hide the timeline inspector
+  const query = `.segment-inspect[data-run_id='${run_id}'][data-segment_number='${segment_number}']`
+  document.querySelector(query).style.visibility = 'hidden'
+
   const timerKey = `${run_id}-${segment_number}`
   if (timelineMouseOverTimers[timerKey] !== undefined) {
     // We just moved our mouse over this segment and then out of it

--- a/app/javascript/timeline.js
+++ b/app/javascript/timeline.js
@@ -1,34 +1,6 @@
 let currentTimelineRunId = ''
-const animationIntervals = {}
 const timelineMouseOverTimers = {}
 const timelineMouseOutTimers = {}
-
-const moveTimeline = (timeline, goldTimeline, videoProgressLine, offset) => {
-  let left = parseFloat(timeline.style.left) || 0
-  const step = (offset - left) / 10
-  if (animationIntervals[timeline.dataset.run_id]) {
-    clearInterval(animationIntervals[timeline.dataset.run_id])
-  }
-  animationIntervals[timeline.dataset.run_id] = setInterval(() => {
-    left += step
-    let position = 'relative'
-    if ((step > 0 && left >= offset) || (step < 0 && left <= offset)) {
-      left = offset
-      clearInterval(animationIntervals[timeline.dataset.run_id])
-      animationIntervals[timeline.dataset.run_id] = undefined
-      if (offset === 0) {
-        position = ''
-      }
-    }
-    timeline.style.position = position
-    timeline.style.left = `${left}px`
-    goldTimeline.style.position = position
-    goldTimeline.style.left = `${left}px`
-    if (videoProgressLine !== null) {
-      videoProgressLine.style.left = `${left}px`
-    }
-  }, 10)
-}
 
 const mouseOverSegment = (segment) => {
   const run_id = segment.dataset.run_id
@@ -47,7 +19,11 @@ const mouseOverSegment = (segment) => {
     const goldTimeline = timeline.parentElement.querySelector('.gold.timeline')
     const videoProgressLine = document.getElementById(`video-progress-line-${el.dataset.run_id}`)
     const offset = leftEdge - otherLeftEdge
-    moveTimeline(timeline, goldTimeline, videoProgressLine, offset)
+    timeline.style.left = `${offset}px`
+    goldTimeline.style.left = `${offset}px`
+    if (videoProgressLine !== null) {
+      videoProgressLine.style.left = `${offset}px`
+    }
   })
 }
 
@@ -67,14 +43,15 @@ const mouseOutSegment = (segment) => {
     return
   }
 
-  const otherTimelinesQuery = `.split[data-segment_number='${segment_number}']:not([data-run_id='${run_id}'])`
-  document.querySelectorAll(otherTimelinesQuery).forEach((el) => {
-    const timeline = el.closest('.timeline-background')
+  const otherTimelinesQuery = `.timeline-background:not([data-run_id='${run_id}'])`
+  document.querySelectorAll(otherTimelinesQuery).forEach((timeline) => {
     const goldTimeline = timeline.parentElement.querySelector('.gold.timeline')
-    const videoProgressLine = document.getElementById(`video-progress-line-${el.dataset.run_id}`)
-    clearInterval(animationIntervals[timeline.dataset.run_id])
-    animationIntervals[timeline.dataset.run_id] = undefined
-    moveTimeline(timeline, goldTimeline, videoProgressLine, 0)
+    const videoProgressLine = document.getElementById(`video-progress-line-${timeline.dataset.run_id}`)
+    timeline.style.left = '0px'
+    goldTimeline.style.left = '0px'
+    if (videoProgressLine !== null) {
+      videoProgressLine.style.left = '0px'
+    }
   })
 }
 
@@ -97,7 +74,7 @@ document.addEventListener('mouseover', event => {
     timelineMouseOutTimers[timerKey] = undefined
   }
   if (timelineMouseOverTimers[timerKey] !== undefined) {
-    // We already have a timer running for thsi segment; don't start another
+    // We already have a timer running for this segment; don't start another
     return
   }
 
@@ -122,7 +99,7 @@ document.addEventListener('mouseout', event => {
   }
 
   if (timelineMouseOutTimers[timerKey] !== undefined) {
-    // We already have a timer running for thsi segment; don't start another
+    // We already have a timer running for this segment; don't start another
     return
   }
 

--- a/app/views/runs/_timeline.slim
+++ b/app/views/runs/_timeline.slim
@@ -4,7 +4,7 @@
 - else
   - if run.video&.supports_embedding?
     div style="height: 1em": span.video-progress-line id="video-progress-line-#{run.id36}"
-  .timeline-background
+  .timeline-background data={run_id: run.id36}
     .timeline.shadow style="width: #{run.duration(timing) / scale_to * 100.0}%"
       - run.collapsed_segments(timing).each.with_index do |segment, index|
         .pure-u.split(

--- a/app/views/runs/_timeline.slim
+++ b/app/views/runs/_timeline.slim
@@ -3,8 +3,8 @@
   .card: .card-body: i This run doesn't have #{timing}time splits.
 - else
   - if run.video&.supports_embedding?
-    div style="height: 1em": span.video-progress-line id="video-progress-line-#{run.id36}"
-  .timeline-background data={run_id: run.id36}
+    div style="height: 1em": span.video-progress-line.timeline-animation id="video-progress-line-#{run.id36}"
+  .timeline-background.timeline-animation data={run_id: run.id36}
     .timeline.shadow style="width: #{run.duration(timing) / scale_to * 100.0}%"
       - run.collapsed_segments(timing).each.with_index do |segment, index|
         .pure-u.split(
@@ -20,7 +20,7 @@
                 = segment.duration(timing).format(precise: run.short?(timing))
               - else
                 b In progress
-  .gold.timeline style="width: #{run.duration(timing) / scale_to * 100.0}%"
+  .gold.timeline.timeline-animation style="width: #{run.duration(timing) / scale_to * 100.0}%"
     - run.collapsed_segments(timing).each_with_index do |segment, index|
       div style="width: #{segment.proportion(timing) * 100.0}%"
         - if segment.shortest_duration(timing).present?


### PR DESCRIPTION
Closes #582 

I feel like this PR is serving as a possibility, but probably not the ultimate solution. It implements @glacials's idea in #582. It works, but it feels sort of jarring as just moving your mouse around causes timelines to jump a bunch.
![timelines](https://user-images.githubusercontent.com/293433/65062553-4500d300-d94a-11e9-91ba-bc2e0230ed3d.gif)

