### PR TITLE
Effort-to-PB chart should use RunHistory for the x-axis

### DIFF
--- a/app/blueprints/api/v4/run_history_blueprint.rb
+++ b/app/blueprints/api/v4/run_history_blueprint.rb
@@ -1,6 +1,21 @@
 class Api::V4::RunHistoryBlueprint < Blueprinter::Base
-  fields :id, :attempt_number, :realtime_duration_ms, :gametime_duration_ms
+  fields :id, :attempt_number, :realtime_duration_ms, :gametime_duration_ms, :started_at, :ended_at
 
-  field(:started_at_ms) { |history, _| (history.started_at || 0).to_f * 1000 }
-  field(:ended_at_ms) { |history, _| (history.ended_at || 0).to_f * 1000 }
+  field(:started_at) do |history, _|
+    if history.started_at
+      history.started_at
+    else
+      DateTime.new(2013, 11, 13, 0, 0, 0)
+    end
+  end
+
+  field(:ended_at) do |history, _|
+    if history.ended_at
+      history.ended_at
+    elsif history.realtime_duration_ms
+      DateTime.new(2013, 11, 13, 0, 0, 0) + (history.realtime_duration_ms / 1000.0).seconds
+    else
+      DateTime.new(2013, 11, 13, 0, 0, 0)
+    end
+  end
 end

--- a/app/blueprints/api/v4/run_history_blueprint.rb
+++ b/app/blueprints/api/v4/run_history_blueprint.rb
@@ -1,21 +1,3 @@
 class Api::V4::RunHistoryBlueprint < Blueprinter::Base
   fields :id, :attempt_number, :realtime_duration_ms, :gametime_duration_ms, :started_at, :ended_at
-
-  field(:started_at) do |history, _|
-    if history.started_at
-      history.started_at
-    else
-      DateTime.new(2013, 11, 13, 0, 0, 0)
-    end
-  end
-
-  field(:ended_at) do |history, _|
-    if history.ended_at
-      history.ended_at
-    elsif history.realtime_duration_ms
-      DateTime.new(2013, 11, 13, 0, 0, 0) + (history.realtime_duration_ms / 1000.0).seconds
-    else
-      DateTime.new(2013, 11, 13, 0, 0, 0)
-    end
-  end
 end

--- a/app/blueprints/api/v4/run_history_blueprint.rb
+++ b/app/blueprints/api/v4/run_history_blueprint.rb
@@ -1,3 +1,6 @@
 class Api::V4::RunHistoryBlueprint < Blueprinter::Base
   fields :id, :attempt_number, :realtime_duration_ms, :gametime_duration_ms
+
+  field(:started_at_ms) { |history, _| history.started_at.to_f * 1000 }
+  field(:ended_at_ms) { |history, _| history.ended_at.to_f * 1000 }
 end

--- a/app/blueprints/api/v4/run_history_blueprint.rb
+++ b/app/blueprints/api/v4/run_history_blueprint.rb
@@ -1,6 +1,6 @@
 class Api::V4::RunHistoryBlueprint < Blueprinter::Base
   fields :id, :attempt_number, :realtime_duration_ms, :gametime_duration_ms
 
-  field(:started_at_ms) { |history, _| history.started_at.to_f * 1000 }
-  field(:ended_at_ms) { |history, _| history.ended_at.to_f * 1000 }
+  field(:started_at_ms) { |history, _| (history.started_at || 0).to_f * 1000 }
+  field(:ended_at_ms) { |history, _| (history.ended_at || 0).to_f * 1000 }
 end

--- a/app/javascript/charts/playtime.js
+++ b/app/javascript/charts/playtime.js
@@ -27,7 +27,6 @@ const buildPlaytimeChart = function(runs, options = {}) {
 
   const playtimeBetweenPBs = runs.map(run => {
     let lastPB = null
-    let playtime = 0
 
     return run.histories.sort(attemptSort).filter(runAttempt => runAttempt[duration] > 0).map(runAttempt => {
       if (lastPB === null || runAttempt[duration] < lastPB[duration]) {

--- a/app/javascript/charts/playtime.js
+++ b/app/javascript/charts/playtime.js
@@ -32,8 +32,7 @@ const buildPlaytimeChart = function(runs, options = {}) {
       if (lastPB === null || runAttempt[duration] < lastPB[duration]) {
         lastPB = runAttempt
         return [
-          run.histories.
-          filter(historicalAttempt => historicalAttempt.attempt_number <= runAttempt.attempt_number).
+          run.histories.filter(historicalAttempt => historicalAttempt.attempt_number <= runAttempt.attempt_number).
           map(historicalAttempt => historicalAttempt.ended_at_ms - historicalAttempt.started_at_ms).
           reduce((playtime, attemptDuration) => playtime + attemptDuration, 0),
           runAttempt[duration]

--- a/app/javascript/charts/playtime.js
+++ b/app/javascript/charts/playtime.js
@@ -33,7 +33,17 @@ const buildPlaytimeChart = function(runs, options = {}) {
         lastPB = runAttempt
         return [
           run.histories.filter(historicalAttempt => historicalAttempt.attempt_number <= runAttempt.attempt_number).
-          map(historicalAttempt => moment(historicalAttempt.ended_at).format('x') - moment(historicalAttempt.started_at).format('x')).
+          map((historicalAttempt) => {
+            let endedAt = moment(historicalAttempt.ended_at).format('x')
+            if (endedAt === 'Invalid date') {
+              endedAt = historicalAttempt.realtime_duration_ms || 0
+            }
+            let startedAt = moment(historicalAttempt.started_at).format('x')
+            if (startedAt === 'Invalid date') {
+              startedAt = 0
+            }
+            return endedAt - startedAt
+          }).
           reduce((playtime, attemptDuration) => playtime + attemptDuration, 0),
           runAttempt[duration]
         ]

--- a/app/javascript/charts/playtime.js
+++ b/app/javascript/charts/playtime.js
@@ -33,7 +33,7 @@ const buildPlaytimeChart = function(runs, options = {}) {
         lastPB = runAttempt
         return [
           run.histories.filter(historicalAttempt => historicalAttempt.attempt_number <= runAttempt.attempt_number).
-          map(historicalAttempt => historicalAttempt.ended_at_ms - historicalAttempt.started_at_ms).
+          map(historicalAttempt => moment(historicalAttempt.ended_at).format('x') - moment(historicalAttempt.started_at).format('x')).
           reduce((playtime, attemptDuration) => playtime + attemptDuration, 0),
           runAttempt[duration]
         ]

--- a/app/javascript/charts/playtime.js
+++ b/app/javascript/charts/playtime.js
@@ -33,10 +33,10 @@ const buildPlaytimeChart = function(runs, options = {}) {
       if (lastPB === null || runAttempt[duration] < lastPB[duration]) {
         lastPB = runAttempt
         return [
-          run.segments.map(segment => segment.histories).flat().
-          filter(segmentAttempt => segmentAttempt.attempt_number <= runAttempt.attempt_number).
-          map(segmentAttempt => segmentAttempt[duration]).
-          reduce((playtime, segmentAttempt) => playtime + segmentAttempt, 0),
+          run.histories.
+          filter(historicalAttempt => historicalAttempt.attempt_number <= runAttempt.attempt_number).
+          map(historicalAttempt => historicalAttempt.ended_at_ms - historicalAttempt.started_at_ms).
+          reduce((playtime, attemptDuration) => playtime + attemptDuration, 0),
           runAttempt[duration]
         ]
       } else {

--- a/docs/api.md
+++ b/docs/api.md
@@ -307,13 +307,13 @@ If a `historic=1` param is included in the request, one additional field will be
 #### History
 History objects have the following format.
 
-| Field                  | Type   | Null? | Description                                                                                |
-|:-----------------------|:-------|:------|:-------------------------------------------------------------------------------------------|
-| `attempt_number`       | number | never | The correpsonding attempt number this attempt was.                                         |
-| `realtime_duration_ms` | number | never | The realtime duration this attempt took in milliseconds.                                   |
-| `gametime_duration_ms` | number | never | The gametime duration this attempt took in milliseconds.                                   |
-| `started_at`           | string | never | The date and time of when the attempt started. This field conforms to [ISO 8601][iso8601]. |
-| `ended_at`             | string | never | The date and time of when the attempt ended. This field conforms to [ISO 8601][iso8601].   |
+| Field                  | Type   | Null?          | Description                                                                                |
+|:-----------------------|:-------|:---------------|:-------------------------------------------------------------------------------------------|
+| `attempt_number`       | number | never          | The correpsonding attempt number this attempt was.                                         |
+| `realtime_duration_ms` | number | never          | The realtime duration this attempt took in milliseconds.                                   |
+| `gametime_duration_ms` | number | never          | The gametime duration this attempt took in milliseconds.                                   |
+| `started_at`           | string | when not known | The date and time of when the attempt started. This field conforms to [ISO 8601][iso8601]. |
+| `ended_at`             | string | when not known | The date and time of when the attempt ended. This field conforms to [ISO 8601][iso8601].   |
 </details>
 
 <details>

--- a/docs/api.md
+++ b/docs/api.md
@@ -307,13 +307,13 @@ If a `historic=1` param is included in the request, one additional field will be
 #### History
 History objects have the following format.
 
-| Field                  | Type   | Null? | Description                                                |
-|:-----------------------|:-------|:------|:-----------------------------------------------------------|
-| `attempt_number`       | number | never | The correpsonding attempt number this attempt was.         |
-| `realtime_duration_ms` | number | never | The realtime duration this attempt took in milliseconds.   |
-| `gametime_duration_ms` | number | never | The gametime duration this attempt took in milliseconds.   |
-| `started_at_ms`        | number | never | The timestamp in milliseconds of when the attempt started. |
-| `ended_at_ms`          | number | never | The timestamp in milliseconds of when the attempt ended.   |
+| Field                  | Type   | Null? | Description                                                                                |
+|:-----------------------|:-------|:------|:-------------------------------------------------------------------------------------------|
+| `attempt_number`       | number | never | The correpsonding attempt number this attempt was.                                         |
+| `realtime_duration_ms` | number | never | The realtime duration this attempt took in milliseconds.                                   |
+| `gametime_duration_ms` | number | never | The gametime duration this attempt took in milliseconds.                                   |
+| `started_at`           | string | never | The date and time of when the attempt started. This field conforms to [ISO 8601][iso8601]. |
+| `ended_at`             | string | never | The date and time of when the attempt ended. This field conforms to [ISO 8601][iso8601].   |
 </details>
 
 <details>

--- a/docs/api.md
+++ b/docs/api.md
@@ -307,11 +307,13 @@ If a `historic=1` param is included in the request, one additional field will be
 #### History
 History objects have the following format.
 
-| Field                  | Type   | Null? | Description                                              |
-|:-----------------------|:-------|:------|:---------------------------------------------------------|
-| `attempt_number`       | number | never | The correpsonding attempt number this attempt was.       |
-| `realtime_duration_ms` | number | never | The realtime duration this attempt took in milliseconds. |
-| `gametime_duration_ms` | number | never | The gametime duration this attempt took in milliseconds. |
+| Field                  | Type   | Null? | Description                                                |
+|:-----------------------|:-------|:------|:-----------------------------------------------------------|
+| `attempt_number`       | number | never | The correpsonding attempt number this attempt was.         |
+| `realtime_duration_ms` | number | never | The realtime duration this attempt took in milliseconds.   |
+| `gametime_duration_ms` | number | never | The gametime duration this attempt took in milliseconds.   |
+| `started_at_ms`        | number | never | The timestamp in milliseconds of when the attempt started. |
+| `ended_at_ms`          | number | never | The timestamp in milliseconds of when the attempt ended.   |
 </details>
 
 <details>


### PR DESCRIPTION
Closes #473

The Effort-to-PB chart now uses `started_at` and `ended_at` from `RunHistory` to calculate playtime until a PB was reached in order to not bunch up attempts at time=0 if a user clears their splits.

I updated the API documentation, but I'm not sure how much of that is autogenerated. Additionally, I'm not sure if you want to add new fields to an existing API or not or wait until the next API version.