### PR TITLE
Remove Run.video_url from the database

### DIFF
--- a/db/migrate/20190915142721_remove_video_url_from_runs.rb
+++ b/db/migrate/20190915142721_remove_video_url_from_runs.rb
@@ -1,0 +1,5 @@
+class RemoveVideoUrlFromRuns < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured { remove_column :runs, :video_url, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_15_142043) do
+ActiveRecord::Schema.define(version: 2019_09_15_142721) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -275,7 +275,6 @@ ActiveRecord::Schema.define(version: 2019_09_15_142043) do
     t.string "program"
     t.string "claim_token"
     t.boolean "archived", default: false, null: false
-    t.string "video_url"
     t.string "srdc_id"
     t.integer "attempts"
     t.string "s3_filename", null: false


### PR DESCRIPTION
This simply removes the `video_url` field from the database as part of #568 / #603. This is step 2 of 3. After this gets deployed, we can remove `self.ignored_columns = ["video_url"]` from `Run` and put `User.pbs` back to how it was.