### PR TITLE
Redo pipeline stuff for faster deploys

### DIFF
--- a/Dockerfile-production
+++ b/Dockerfile-production
@@ -1,5 +1,5 @@
 ARG RUBY_VERSION
-FROM ruby:$RUBY_VERSION-alpine AS builder
+FROM ruby:$RUBY_VERSION-alpine AS prod-builder
 
 # Build base for gem's native extensions
 # tzdata for ruby timezone data
@@ -27,7 +27,7 @@ WORKDIR /app
 
 COPY Gemfile* package.json yarn.lock ./
 
-RUN bundle install --without development:test \
+RUN bundle install -j "$(expr "$(getconf _NPROCESSORS_ONLN)" - 1)" --without development:test \
     && rm -rf $BUNDLE_PATH/cache/*.gem \
     && find $BUNDLE_PATH/gems/ -name "*.c" -delete \
     && find $BUNDLE_PATH/gems/ -name "*.o" -delete
@@ -45,7 +45,7 @@ RUN rm -rf node_modules/ tmp/cache app/assets vendor/assets spec
 
 #############
 
-FROM ruby:$RUBY_VERSION-alpine
+FROM ruby:$RUBY_VERSION-alpine AS prod-runtime
 
 ENV RAILS_ENV=production \
     NODE_ENV=production \
@@ -62,7 +62,7 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/reposit
     && apk add -u --no-cache tzdata gcompat postgresql-dev bash nodejs-current \
     && rm -rf /var/cache/apk/*
 
-COPY --from=builder /app /app
-COPY --from=builder /bundle /bundle
+COPY --from=prod-builder /app /app
+COPY --from=prod-builder /bundle /bundle
 
 WORKDIR /app

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,9 +1,4 @@
 version: '3.7'
-x-args:
-  &server-args
-    RUBY_VERSION: '2.6.3' # also update docker-compose.yml & Gemfile
-    SPLITSIO_CLIENT_ID: $SPLITSIO_CLIENT_ID
-    STRIPE_PUBLISHABLE_KEY: $STRIPE_PUBLISHABLE_KEY
 x-environment:
   &server-environment
   - ASSET_HOST
@@ -47,25 +42,28 @@ x-logging:
     max-size: 100m
     max-file: "1"
 
+x-app: &app
+  build:
+    context: .
+    dockerfile: Dockerfile-production
+    target: "${DOCKER_BUILD_TARGET:-prod-runtime}"
+    cache_from:
+      - "${REPOSITORY_URI:-splitsio-production}:latest"
+    args:
+      RUBY_VERSION: '2.6.3' # also update docker-compose.yml & Gemfile
+      SPLITSIO_CLIENT_ID: $SPLITSIO_CLIENT_ID
+      STRIPE_PUBLISHABLE_KEY: $STRIPE_PUBLISHABLE_KEY
+  environment: *server-environment
+  image: splitsio-production
+  logging: *default-logging
+
 services:
   web:
-    build:
-      context: .
-      dockerfile: Dockerfile-production
-      args: *server-args
+    <<: *app
     command: bash -c "rm -f /app/tmp/pids/server.pid && bundle exec rails db:migrate && bundle exec rails s -p 3000 -b '0.0.0.0'"
-    environment: *server-environment
-    image: web-production
-    logging: *default-logging
     ports:
       - 3000:3000
   worker:
-    build:
-      context: .
-      dockerfile: Dockerfile-production
-      args: *server-args
+    <<: *app
     command: bash -c "rm -f /app/tmp/pids/delayed*.pid && bundle exec rake jobs:work" # bin/delayed_job doesn't obey QUEUES
-    environment: *server-environment
-    image: worker-production
-    logging: *default-logging
     ports: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,11 @@ x-app: &app
   build:
     context: .
     dockerfile: Dockerfile
+    cache_from:
+      - "${REPOSITORY_URI:-splitsio-dev}:latest"
     args:
       RUBY_VERSION: '2.6.3' # also update docker-compose-production.yml & Gemfile
+  image: splitsio-dev
   tmpfs:
     - /tmp
 x-backend: &backend
@@ -80,7 +83,6 @@ services:
     <<: *app
     command: bash -c "ruby bin/webpack-dev-server"
     environment: *client-environment
-    image: webpacker
     logging: *default-logging
     ports:
       - 3035:3035
@@ -93,7 +95,6 @@ services:
     <<: *backend
     command: bash -c "rm -f /app/tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     environment: *server-environment
-    image: web
     logging: *default-logging
     ports:
       - 3000:3000
@@ -101,7 +102,6 @@ services:
     <<: *backend
     command: bash -c "rm -f /app/tmp/pids/delayed*.pid && bundle exec rake jobs:work"
     environment: *server-environment
-    image: worker
     logging: *default-logging
   redis:
     image: redis:5.0.5-alpine

--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
 cd /app
-docker load < dist.tar
-rm dist.tar
+export REPOSITORY_URI="767531804574.dkr.ecr.us-east-1.amazonaws.com/splitsio-prod-builder"
+$(aws ecr get-login --no-include-email --region us-east-1)
+docker pull $REPOSITORY_URI:latest
+source ~/.env
+/usr/local/bin/docker-compose -f docker-compose-production.yml build web


### PR DESCRIPTION
Re-speed up our deploys after the docker environment changed nuked it.  I think this depends on the updated pipeline being in place first, but I don't see anything in my changes specifically that require it.  But just to be safe this should be merged after the new pipeline is set up.