### PR TITLE
Fix stream deck selections

### DIFF
--- a/app/javascript/vue/race-streams.js
+++ b/app/javascript/vue/race-streams.js
@@ -36,9 +36,9 @@ export default {
 
     getBreakPointDiv: function(desiredBreak) {
       const breakPointDiv = document.createElement('div')
-      const allSizes = ['xs', 'sm', 'md', 'lg', 'xl']
+      const allSizes = ['sm', 'md', 'lg', 'xl']
       const breakpoints = allSizes.map(size => size === desiredBreak ? `d-${size}-block` : `d-${size}-none`)
-      if (desiredBreak !== 'xs') { breakpoints.unshift('d-none') }
+      breakpoints.unshift(desiredBreak === 'xs' ? 'd-block' : 'd-none')
       breakPointDiv.className = `w-100 ${breakpoints.join(' ')}`
       return breakPointDiv
     }
@@ -49,7 +49,7 @@ export default {
 
     // We have to manually add and remove breakpoints in JS otherwise we cannot utilize :key on the card div
     // Without :key all iframes after the removed one will reload
-    deck.querySelectorAll('.w-100').forEach(breakpoint => {
+    deck.querySelectorAll('#stream-deck .w-100').forEach(breakpoint => {
       breakpoint.parentNode.removeChild(breakpoint)
     })
 

--- a/app/javascript/vue/race-streams.js
+++ b/app/javascript/vue/race-streams.js
@@ -32,26 +32,38 @@ export default {
       const width = div.offsetWidth
 
       return (width / 16) * 9
+    },
+
+    getBreakPointDiv: function(desiredBreak) {
+      const breakPointDiv = document.createElement('div')
+      const allSizes = ['xs', 'sm', 'md', 'lg', 'xl']
+      const breakpoints = allSizes.map(size => size === desiredBreak ? `d-${size}-block` : `d-${size}-none`)
+      if (desiredBreak !== 'xs') { breakpoints.unshift('d-none') }
+      breakPointDiv.className = `w-100 ${breakpoints.join(' ')}`
+      return breakPointDiv
     }
   },
 
   updated: function() {
-    this.value.forEach(stream => {
-      const div = document.getElementById(`twitch-${stream.id}`)
-      const child = div.firstChild
-      if (div.dataset.loaded === '1') {
-        child.height = this.ratioHeight(div)
-        return
-      }
+    const deck = document.getElementById('stream-deck')
 
-      div.dataset.loaded = '1'
-      new Twitch.Player(div.id, {
-        autoplay: true,
-        channel: stream.id,
-        muted: true,
-        height: this.ratioHeight(div),
-        width: '100%'
-      })
+    // We have to manually add and remove breakpoints in JS otherwise we cannot utilize :key on the card div
+    // Without :key all iframes after the removed one will reload
+    deck.querySelectorAll('.w-100').forEach(breakpoint => {
+      breakpoint.parentNode.removeChild(breakpoint)
+    })
+
+    deck.querySelectorAll('.card').forEach((card, i) => {
+      deck.insertBefore(this.getBreakPointDiv('xs'), card.nextSibling)
+      if (i + 1 === 2) { deck.insertBefore(this.getBreakPointDiv('md'), card.nextSibling) }
+      if (i + 1 === 3) { deck.insertBefore(this.getBreakPointDiv('lg'), card.nextSibling) }
+      if (i + 1 === 4) { deck.insertBefore(this.getBreakPointDiv('xl'), card.nextSibling) }
+    })
+
+    // Resize iframe divs in their dynamic column/rows
+    document.querySelectorAll('.twitch-stream').forEach(div => {
+      const iframe = div.firstChild
+      iframe.height = this.ratioHeight(div)
     })
   },
   name: 'race-streams',

--- a/app/views/races/index.slim
+++ b/app/views/races/index.slim
@@ -22,7 +22,7 @@ article
         li.nav-item
           = link_to('Historic', races_path(historic: '1'), class: "nav-link #{historic ? 'active' : ''}")
     = render partial: 'shared/race_table', locals: {races: races}
-    - if params[:historic] == '1'
+    - if params[:historic] != '1'
       .card-footer
         small
           ' Showing races active in the last hour and races with more than one entrant. Races longer than 48 hours are

--- a/app/views/races/show.slim
+++ b/app/views/races/show.slim
@@ -106,7 +106,6 @@
                 .card v-for='stream in value' :key='stream.id'
                   .card-body.p-0.twitch-stream
                     iframe(
-                      :key='`iframe-${stream.id}`'
                       :src='`https://player.twitch.tv/?channel=${stream.id}&muted=true`'
                       height='100%'
                       width='100%'

--- a/app/views/races/show.slim
+++ b/app/views/races/show.slim
@@ -102,11 +102,16 @@
                     span class="multiselect__single" v-if="values.length && !isOpen"
                       ' {{ value.length }}/{{ options.length }} options selected
             .card-body
-              .card-deck
-                template v-for='(stream, index) in value'
-                  .card: .card-body.p-0 :id='`twitch-${stream.id}`'
-                  .w-100.d-sm-none
-                  .w-100.d-none.d-md-block.d-lg-none v-if='(index + 1) % 2 === 0'
-                  .w-100.d-none.d-lg-block.d-xl-none v-if='(index + 1) % 3 === 0'
-                  .w-100.d-none.d-xl-block v-if='(index + 1) % 4 === 0'
+              .card-deck#stream-deck
+                .card v-for='stream in value' :key='stream.id'
+                  .card-body.p-0.twitch-stream
+                    iframe(
+                      :key='`iframe-${stream.id}`'
+                      :src='`https://player.twitch.tv/?channel=${stream.id}&muted=true`'
+                      height='100%'
+                      width='100%'
+                      frameborder='0'
+                      scrolling='no'
+                      allowfullscreen='true'
+                    )
               .center v-if='value.length === 0' Select streams to show from the box above


### PR DESCRIPTION
Closes #622

For such a small amount of changes this took me forever to figure out so I'll explain it for anyone else who might stumble into this.

Vue uses in place replacement by default for its `v-for` directive, which is why the last iframe was being deleted.  As far as it was concerned every div was identical so it would update the backing data and then just cut the last div.  There is a way to change this behavior though (which is highly recommended by the docs), and that is to set a `:key='xxx'` on the `v-for`.  This key needs to be unique across all elements that you are iterating over.  It can then use this to diff the iterated div and only replace those that have changed data.  However, since `template` is not an element but merely a helper, you cannot set `:key` on a template.

Since we're using Bootstrap 4.0, we don't have access to the newer versions which have more responsiveness built in (which may or may not fix the breakpoint thing later, would need testing first) we have to manually create breakpoints for every size after every card we put in.  Using a template allowed us to put the breakpoints in the template right after the card, super convenient and all in one place.  Card decks however require cards to be at the top level for the sizing to be done properly, which means that in order to swap out the template to be a card directly, we would need to move the breakpoint code somewhere else (span/div containing everything will not size correctly).

Inadvertently while testing a ton of things to figure out what the problem was originally, I found out that we don't need the interactive iFrame embed from Twitch, which means the code is a bit simpler since we just put the iFrame code directly into the template itself instead of needing to worry about loading it once and only once.