### PR TITLE
Remove Run.ignored_columns

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -2,9 +2,6 @@ Dir['./lib/programs/*'].each { |file| require file }
 require './lib/parser/livesplit_core_parser'
 
 class Run < ApplicationRecord
-  # TODO: Remove self.ignored_columns after the next deploy when the migration to remove the column from the DB is run
-  self.ignored_columns = ["video_url"] # Remove this after deployed and migration to remove the column runs
-
   include CompletedRun
   include ForgetfulPersonsRun
   include PadawanRun

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,10 +76,7 @@ class User < ApplicationRecord
   end
 
   def pbs
-    # TODO: Put the SELECT * back in after Run.ignored_columns is removed
-    # runs.where.not(category: nil).select('DISTINCT ON (category_id) *').order('category_id, realtime_duration_ms ASC')
-    column_names = Run.attribute_names.join(',')
-    runs.where.not(category: nil).select("DISTINCT ON (category_id) #{column_names}").order('category_id, realtime_duration_ms ASC')
+    runs.where.not(category: nil).select('DISTINCT ON (category_id) *').order('category_id, realtime_duration_ms ASC')
         .union_all(runs.by_category(nil))
   end
 


### PR DESCRIPTION
This removes `Run.ignored_columns` and reverts `User.pbs` to use `SELECT *` now that `Run.video_url` has been completely removed from the DB. This is the final step of  #568 / #603.