### PR TITLE
Use fuzzy matching for timeline comparisons when there are a differing number of segments

### DIFF
--- a/app/javascript/timeline.js
+++ b/app/javascript/timeline.js
@@ -1,3 +1,5 @@
+import FuzzySet from 'fuzzyset.js'
+
 let currentTimelineRunId = ''
 const timelineMouseOverTimers = {}
 const timelineMouseOutTimers = {}
@@ -9,8 +11,23 @@ const mouseOverSegment = (segment) => {
   timelineMouseOverTimers[timerKey] = undefined
 
   const leftEdge = segment.offsetLeft
-  const otherTimelinesQuery = `.split[data-segment_number='${segment_number}']:not([data-run_id='${run_id}'])`
-  document.querySelectorAll(otherTimelinesQuery).forEach((el) => {
+  const splits = []
+
+  document.querySelectorAll(`.timeline-background:not([data-run_id='${run_id}'])`).forEach((timeline) => {
+    const segmentNames = FuzzySet(JSON.parse(timeline.dataset.segment_names))
+    const closestSegments = segmentNames.get(segment.dataset.segment_name)
+    let segmentName = undefined
+    if (closestSegments && closestSegments[0][0] > 0.5) {
+      segmentName = closestSegments[0][1]
+      splits.push(timeline.querySelector(`.split[data-segment_name='${segmentName}']`))
+    } else {
+      const split = timeline.querySelector(`.split[data-segment_number='${segment_number}']`)
+      if (split) {
+        splits.push(split)
+      }
+    }
+  })
+  splits.forEach((el) => {
     const otherLeftEdge = el.offsetLeft
     const timeline = el.closest('.timeline-background')
     const goldTimeline = timeline.parentElement.querySelector('.gold.timeline')

--- a/app/javascript/timeline.js
+++ b/app/javascript/timeline.js
@@ -5,17 +5,16 @@ const timelineMouseOverTimers = {}
 const timelineMouseOutTimers = {}
 
 const matchingSplitForTimeline = (segment, timeline) => {
-  const segmentNames = FuzzySet(JSON.parse(timeline.dataset.segment_names))
-  let segmentName = undefined
   if (segment.dataset.total_segments === timeline.dataset.total_segments) {
     const split = timeline.querySelector(`.split[data-segment_number='${segment.dataset.segment_number}']`)
     if (split) {
       return split
     }
   } else {
+    const segmentNames = FuzzySet(JSON.parse(timeline.dataset.segment_names))
     const closestSegments = segmentNames.get(segment.dataset.segment_name)
     if (closestSegments && closestSegments[0][0] > 0.5) {
-      segmentName = closestSegments[0][1]
+      const segmentName = closestSegments[0][1]
       return timeline.querySelector(`.split[data-segment_name='${segmentName}']`)
     }
   }

--- a/app/javascript/timeline.js
+++ b/app/javascript/timeline.js
@@ -4,6 +4,23 @@ let currentTimelineRunId = ''
 const timelineMouseOverTimers = {}
 const timelineMouseOutTimers = {}
 
+const matchingSplitForTimeline = (segment, timeline) => {
+  const segmentNames = FuzzySet(JSON.parse(timeline.dataset.segment_names))
+  let segmentName = undefined
+  if (segment.dataset.total_segments === timeline.dataset.total_segments) {
+    const split = timeline.querySelector(`.split[data-segment_number='${segment.dataset.segment_number}']`)
+    if (split) {
+      return split
+    }
+  } else {
+    const closestSegments = segmentNames.get(segment.dataset.segment_name)
+    if (closestSegments && closestSegments[0][0] > 0.5) {
+      segmentName = closestSegments[0][1]
+      return timeline.querySelector(`.split[data-segment_name='${segmentName}']`)
+    }
+  }
+}
+
 const mouseOverSegment = (segment) => {
   const run_id = segment.dataset.run_id
   const segment_number = segment.dataset.segment_number
@@ -14,17 +31,9 @@ const mouseOverSegment = (segment) => {
   const splits = []
 
   document.querySelectorAll(`.timeline-background:not([data-run_id='${run_id}'])`).forEach((timeline) => {
-    const segmentNames = FuzzySet(JSON.parse(timeline.dataset.segment_names))
-    const closestSegments = segmentNames.get(segment.dataset.segment_name)
-    let segmentName = undefined
-    if (closestSegments && closestSegments[0][0] > 0.5) {
-      segmentName = closestSegments[0][1]
-      splits.push(timeline.querySelector(`.split[data-segment_name='${segmentName}']`))
-    } else {
-      const split = timeline.querySelector(`.split[data-segment_number='${segment_number}']`)
-      if (split) {
-        splits.push(split)
-      }
+    const split = matchingSplitForTimeline(segment, timeline)
+    if (split) {
+      splits.push(split)
     }
   })
   splits.forEach((el) => {

--- a/app/views/runs/_timeline.slim
+++ b/app/views/runs/_timeline.slim
@@ -4,12 +4,13 @@
 - else
   - if run.video&.supports_embedding?
     div style="height: 1em": span.video-progress-line.timeline-animation id="video-progress-line-#{run.id36}"
-  .timeline-background.timeline-animation data={run_id: run.id36, segment_names: run.collapsed_segments(timing).map(&:name)}
+  - collapsed_segments = run.collapsed_segments(timing)
+  .timeline-background.timeline-animation data={run_id: run.id36, segment_names: collapsed_segments.map(&:display_name), total_segments: collapsed_segments.length}
     .timeline.shadow style="width: #{run.duration(timing) / scale_to * 100.0}%"
-      - run.collapsed_segments(timing).each.with_index do |segment, index|
+      - collapsed_segments.each.with_index do |segment, index|
         .pure-u.split(
           id="#{run.id36}-split-#{index}"
-          data={start_ms: segment.start(timing).to_ms, run_id: run.id36, segment_name: segment.name, segment_number: index+1}
+          data={start_ms: segment.start(timing).to_ms, run_id: run.id36, segment_name: segment.display_name, segment_number: index+1, total_segments: collapsed_segments.length}
           class="#{next_timeline_color(run.id36)} #{'progress-bar-striped progress-bar-animated' if segment.duration(timing).nil?}"
           style="width: #{segment.proportion(timing) * 100.0}%; z-index: #{index}; #{'cursor: pointer;' if run.video}"
         )
@@ -21,7 +22,7 @@
               - else
                 b In progress
   .gold.timeline.timeline-animation style="width: #{run.duration(timing) / scale_to * 100.0}%"
-    - run.collapsed_segments(timing).each_with_index do |segment, index|
+    - collapsed_segments.each_with_index do |segment, index|
       div style="width: #{segment.proportion(timing) * 100.0}%"
         - if segment.shortest_duration(timing).present?
           .gold-split style="width: #{segment.shortest_duration(timing) / segment.duration(timing) * 100.0}%"

--- a/app/views/runs/_timeline.slim
+++ b/app/views/runs/_timeline.slim
@@ -4,12 +4,12 @@
 - else
   - if run.video&.supports_embedding?
     div style="height: 1em": span.video-progress-line.timeline-animation id="video-progress-line-#{run.id36}"
-  .timeline-background.timeline-animation data={run_id: run.id36}
+  .timeline-background.timeline-animation data={run_id: run.id36, segment_names: run.collapsed_segments(timing).map(&:name)}
     .timeline.shadow style="width: #{run.duration(timing) / scale_to * 100.0}%"
       - run.collapsed_segments(timing).each.with_index do |segment, index|
         .pure-u.split(
           id="#{run.id36}-split-#{index}"
-          data={start_ms: segment.start(timing).to_ms, run_id: run.id36, segment_number: index+1}
+          data={start_ms: segment.start(timing).to_ms, run_id: run.id36, segment_name: segment.name, segment_number: index+1}
           class="#{next_timeline_color(run.id36)} #{'progress-bar-striped progress-bar-animated' if segment.duration(timing).nil?}"
           style="width: #{segment.proportion(timing) * 100.0}%; z-index: #{index}; #{'cursor: pointer;' if run.video}"
         )

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "driftless": "^2.0.3",
     "expose-loader": "^0.7.5",
     "file-saver": "^2.0.2",
+    "fuzzyset.js": "^0.0.8",
     "handlebars": "^4.2.0",
     "highcharts": "^7.2.0",
     "highcharts-regression": "streamlinesocial/highcharts-regression",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3181,6 +3181,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+fuzzyset.js@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/fuzzyset.js/-/fuzzyset.js-0.0.8.tgz#398311fb54a5f84221db2cb143ac8cf1e523ae50"
+  integrity sha512-wymI6DYJgCBDFUrIyA/M2gIjJPEWj40pnCf04+Dma0PaprQRrTRh9/Cmz1wl9jCJxA+iqrCqNrGYuq7lVOtzXQ==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
Closes #619 

This uses fuzzy matching to line up timelines when there are differing numbers of splits between timelines. It's currently holding the position of the timelines when mousing over a segment without a good enough match as opposed to returning to the origin to cut down on timelines snapping about.

It doesn't currently display any sort of message on a non-match like @BatedUrGonnaDie talked about. Clearly that can happen; I wanted to get this in front of people first and then iterate if needed.