### PR TITLE
Fixes category names for the Run Progress chart

### DIFF
--- a/app/javascript/charts/run_progress.js
+++ b/app/javascript/charts/run_progress.js
@@ -37,7 +37,7 @@ const buildRunProgressChart = function(runs, options = {}) {
     series: runs.map((run, i) => (
       {
         data: run.segments.map((segment) => (
-          [segment.dispaly_name, parseFloat((segment.histories.length / run.attempts * 100).toFixed(1)), 20]
+          [`${segment.display_name} - ${segment.segment_number}`, parseFloat((segment.histories.length / run.attempts * 100).toFixed(1)), 20]
         )),
         name: (run.runners[0] || {name: '???'}).name,
         colorByPoint: runs.length == 1,


### PR DESCRIPTION
This addresses two problems.

1. There was a typo in using `display_name` for segments after adding segment groups.
1. If multiple segments have the same name, they will stack on the same datapoint, which sort of defeats the purpose of the chart. This fixes that.