### PR TITLE
Add simple game name sorting to games#index

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -39,7 +39,7 @@ class GamesController < ApplicationController
 
   def set_games
     @games = Hash.new { |h, k| h[k] = [] }
-    SpeedrunDotComGame.order('ASCII(name) ASC').each do |game|
+    SpeedrunDotComGame.order('ASCII(name) ASC, UPPER(name) ASC').each do |game|
       @games[game.name[0].downcase] << game
     end
   end


### PR DESCRIPTION
This maintains the existing overall by-first-character sorting currently on the `games#index` page, but adds intra-character-group sorting that makes sense to people.