### PR TITLE
Random segment group cleanup

### DIFF
--- a/app/javascript/charts/segment_duration.js
+++ b/app/javascript/charts/segment_duration.js
@@ -30,7 +30,7 @@ const buildSegmentDurationChart = function(timing, runs, segments, options = {})
       }
     },
     series: segments.filter(Boolean).map((segment, i) => ({
-      name: `${(runs[i].runners[0] || {name: '???'}).name}'s ${segment.name}`,
+      name: `${(runs[i].runners[0] || {name: '???'}).name}'s ${segment.display_name}`,
       data: (segment.filteredHistories || segment.histories).map(attempt => {
         return [`Attempt #${attempt.attempt_number}`, attempt[duration]]
       }),

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -177,6 +177,7 @@ class Run < ApplicationRecord
     segments_with_groups.select(&:segment_group_parent?).map do |segment|
       {
         id:             segment.id,
+        display_name:   segment.display_name,
         name:           segment.display_name,
         segment_number: segment.segment_number,
         histories:      segment.segment_group_durations

--- a/app/models/segment_group.rb
+++ b/app/models/segment_group.rb
@@ -97,8 +97,8 @@ class SegmentGroup
       segment.histories.each do |history|
         previous_segment = segments[segment.segment_number - 1]&.histories&.find { |attempt| attempt.attempt_number == history.attempt_number }
         # Don't store a segment's duration if it is 0 or if the previous segment's duration was 0 (and thus skipped)
-        @durations_by_attempt[Run::REAL][history.attempt_number] << history.realtime_duration_ms unless history.realtime_duration_ms == 0 || previous_segment&.realtime_duration_ms == 0
-        @durations_by_attempt[Run::GAME][history.attempt_number] << history.gametime_duration_ms unless history.gametime_duration_ms == 0 || previous_segment&.gametime_duration_ms == 0
+        @durations_by_attempt[Run::REAL][history.attempt_number] << history.realtime_duration_ms unless (history.realtime_duration_ms || 0) == 0 || (previous_segment && (previous_segment.realtime_duration_ms || 0) == 0)
+        @durations_by_attempt[Run::GAME][history.attempt_number] << history.gametime_duration_ms unless (history.gametime_duration_ms || 0) == 0 || (previous_segment && (previous_segment.gametime_duration_ms || 0) == 0)
       end
     end
 

--- a/app/models/segment_group.rb
+++ b/app/models/segment_group.rb
@@ -30,7 +30,7 @@ class SegmentGroup
   end
 
   def reduced?(timing)
-    false
+    segments.first.reduced?(timing)
   end
 
   def segment_group_parent?
@@ -42,7 +42,7 @@ class SegmentGroup
   end
 
   def skipped?(timing)
-    false
+    segments.all? { |segment| segment.skipped?(timing) }
   end
 
   def shortest_duration(timing)


### PR DESCRIPTION
1. Segment Groups needed `display_name` added to the values sent to charts
1. The `segment_duration` charts needed to use `display_name`
1. `SegmentHistories` with `nil` values for durations weren't being filtered out of the stats for segment groups, so it was throwing off means, segment duration charts, etc.
1. I went ahead and added sensible return values for `skipped?` and `reduced?` for `SegmentGroup`.