### PR TITLE
Fixed font issues on scrolling charts

### DIFF
--- a/app/javascript/highchart_theme.js
+++ b/app/javascript/highchart_theme.js
@@ -2,6 +2,8 @@
 import Highcharts from 'highcharts'
 import {blue, purple, green, yellow, red, orange} from 'colors.js'
 
+const defaultFontFamily = '"Helvetica Neue", Helvetica, Arial, sans-serif'
+
 Highcharts.theme = {
   colors: [
     blue,
@@ -14,7 +16,7 @@ Highcharts.theme = {
   chart: {
     backgroundColor: 'none',
     style: {
-     fontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif'
+     fontFamily: defaultFontFamily
    },
    plotBorderColor: '#606063'
   },
@@ -22,12 +24,14 @@ Highcharts.theme = {
   title: {
     style: {
       color: '#FFFFFF',
+      fontFamily: defaultFontFamily,
       fontSize: '20px'
     }
   },
   subtitle: {
     style: {
       color: '#E0E0E3',
+      fontFamily: defaultFontFamily
     }
   },
 
@@ -51,7 +55,8 @@ Highcharts.theme = {
     gridLineColor: '#707070',
     labels: {
       style: {
-        color: '#FFF'
+        color: '#FFF',
+        fontFamily: defaultFontFamily
       }
     },
     lineColor: '#707070',
@@ -60,7 +65,8 @@ Highcharts.theme = {
     tickWidth: 1,
     title: {
       style: {
-        color: '#FFFFFF'
+        color: '#FFFFFF',
+        fontFamily: defaultFontFamily
       }
     }
   },
@@ -94,7 +100,8 @@ Highcharts.theme = {
 
   legend: {
     itemStyle: {
-      color: '#E0E0E3'
+      color: '#E0E0E3',
+      fontFamily: defaultFontFamily
     },
     itemHoverStyle: {
       color: '#FFF'


### PR DESCRIPTION
Closes #621 

For whatever reason, scrolling charts don't use the font-family defined in the `chart.style` portion of the Highcharts options. I can't find anything about it in the documentation or online.

You can play around with it using a [JSFiddle](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/chart/style-serif-font/) linked from the documentation and watch it break down as soon as you make the chart scroll.

This PR just specifies the font-family for a bunch of the areas that were using the Highcharts default as opposed to the specified font-family.

Shoutout to @wooferzfg for noticing it was a scrolling chart issue in Discord.