### PR TITLE
Fix Segment Group Issues

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -242,8 +242,8 @@ class Run < ApplicationRecord
     segment_array.each_with_index do |segment, i|
       if !segment_group_start_index && segment.subsplit?
         segment_group_start_index = i
-        segment_group_end_index = segment_array[i..-1].index(&:last_subsplit?) + i
-        @segments_with_groups << SegmentGroup.new(self, segment_array[segment_group_start_index..segment_group_end_index])
+        segment_group_end_index = (segment_array[i..-1].index(&:last_subsplit?) || 0) + i
+        @segments_with_groups << SegmentGroup.new(self, segment_array[segment_group_start_index..segment_group_end_index]) unless segment_group_start_index == segment_group_end_index
       end
       if segment_group_end_index == i
         segment_group_start_index = nil

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -211,7 +211,7 @@ class Segment < ApplicationRecord
   def subsplit?
     return false if name.blank?
 
-    /^[-\{]/.match?(name)
+    /^(?:-|\{.*?}\s*).+/.match?(name)
   end
 
   # last_subsplit? returns something truthy representing if this segment is the last subsplit of a segment group
@@ -223,6 +223,7 @@ class Segment < ApplicationRecord
   def display_name
     return name unless subsplit?
 
-    /^(?:-|\{.*?}\s*)(.+)/.match(name)[1]
+    matched_name = /^(?:-|\{.*?}\s*)(.+)/.match(name)
+    matched_name ? matched_name[1] : name
   end
 end

--- a/spec/factories/run_factory.rb
+++ b/spec/factories/run_factory.rb
@@ -3,33 +3,35 @@ FactoryBot.define do
     # factory name:           {filename: 'filename-within-spec/factories/run_files},
 
     # timer runs
-    livesplit14:              {filename: 'livesplit1.4'},
-    livesplit15:              {filename: 'livesplit1.5.lss'},
-    livesplit16:              {filename: 'livesplit1.6'},
-    livesplit16_gametime:     {filename: 'livesplit1.6_gametime.lss'},
-    livesplit_no_realtime:    {filename: 'livesplit_no_realtime.lss'},
-    llanfair:                 {filename: 'llanfair'},
-    llanfair_gered:           {filename: 'llanfair_gered.lfs'},
-    llanfair_gered_with_refs: {filename: 'llanfair_gered_with_refs.lfs'},
-    splitsio_exchange:        {filename: 'splitsio_exchange/b.json'},
-    wsplit:                   {filename: 'wsplit'},
-    timesplittracker:         {filename: 'timesplittracker.txt'},
+    livesplit14:                     {filename: 'livesplit1.4'},
+    livesplit15:                     {filename: 'livesplit1.5.lss'},
+    livesplit16:                     {filename: 'livesplit1.6'},
+    livesplit16_gametime:            {filename: 'livesplit1.6_gametime.lss'},
+    livesplit_no_realtime:           {filename: 'livesplit_no_realtime.lss'},
+    llanfair:                        {filename: 'llanfair'},
+    llanfair_gered:                  {filename: 'llanfair_gered.lfs'},
+    llanfair_gered_with_refs:        {filename: 'llanfair_gered_with_refs.lfs'},
+    splitsio_exchange:               {filename: 'splitsio_exchange/b.json'},
+    wsplit:                          {filename: 'wsplit'},
+    timesplittracker:                {filename: 'timesplittracker.txt'},
 
     # a bad run and a better run from the same category, against which suggestions can be generated
-    compare_subject:          {filename: 'compare_subject.lss'},
-    compare_object:           {filename: 'compare_object.lss'},
+    compare_subject:                 {filename: 'compare_subject.lss'},
+    compare_object:                  {filename: 'compare_object.lss'},
 
     # specific-content runs
-    with_segments_bests:      {filename: 'with_segments_bests.lss'},
+    with_segments_bests:             {filename: 'with_segments_bests.lss'},
 
     # skipped splits
-    skipped_splits:           {filename: 'livesplit_skipped_splits.lss'},
+    skipped_splits:                  {filename: 'livesplit_skipped_splits.lss'},
 
     # subsplit
-    subsplits_with_titles:    {filename: 'livesplit_subsplits.lss'},
-    subsplits_without_titles: {filename: 'livesplit_subsplits_without_titles.lss'},
+    subsplits_braces_with_no_dashes: {filename: 'livesplit_subsplit_braces_with_no_dashes.lss'},
+    subsplits_ends_with_dash:        {filename: 'livesplit_subsplit_ends_with_dash.lss'},
+    subsplits_with_titles:           {filename: 'livesplit_subsplits.lss'},
+    subsplits_without_titles:        {filename: 'livesplit_subsplits_without_titles.lss'},
 
-    nameless_segments:        {filename: 'livesplit_nameless_segments.lss'}
+    nameless_segments:               {filename: 'livesplit_nameless_segments.lss'}
   }
 
   test_files.each do |_factory_name, file|

--- a/spec/factories/run_files/livesplit_subsplit_braces_with_no_dashes.lss
+++ b/spec/factories/run_files/livesplit_subsplit_braces_with_no_dashes.lss
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Run version="1.7.0">
+  <GameIcon />
+  <GameName>El Tigre</GameName>
+  <CategoryName>Miracle City</CategoryName>
+  <Metadata>
+    <Run id="" />
+    <Platform usesEmulator="False">
+    </Platform>
+    <Region>
+    </Region>
+    <Variables />
+  </Metadata>
+  <Offset>00:00:00</Offset>
+  <AttemptCount>2</AttemptCount>
+  <AttemptHistory>
+    <Attempt id="1" started="10/20/2019 08:59:40" isStartedSynced="False" ended="10/20/2019 09:12:03" isEndedSynced="False">
+      <RealTime>00:12:22.8767050</RealTime>
+    </Attempt>
+  </AttemptHistory>
+  <Segments>
+    <Segment>
+      <Name>Piñata 1</Name>
+      <Icon />
+      <SplitTimes>
+        <SplitTime name="Personal Best">
+          <RealTime>00:03:36.8777640</RealTime>
+        </SplitTime>
+      </SplitTimes>
+      <BestSegmentTime>
+        <RealTime>00:03:36.8777640</RealTime>
+      </BestSegmentTime>
+      <SegmentHistory>
+        <Time id="1">
+          <RealTime>00:03:36.8777640</RealTime>
+        </Time>
+      </SegmentHistory>
+    </Segment>
+    <Segment>
+      <Name>Piñata 2</Name>
+      <Icon />
+      <SplitTimes>
+        <SplitTime name="Personal Best">
+          <RealTime>00:07:30.7939750</RealTime>
+        </SplitTime>
+      </SplitTimes>
+      <BestSegmentTime>
+        <RealTime>00:03:53.9162100</RealTime>
+      </BestSegmentTime>
+      <SegmentHistory>
+        <Time id="1">
+          <RealTime>00:03:53.9162100</RealTime>
+        </Time>
+      </SegmentHistory>
+    </Segment>
+    <Segment>
+      <Name>Piñata 3</Name>
+      <Icon />
+      <SplitTimes>
+        <SplitTime name="Personal Best">
+          <RealTime>00:11:39.1242190</RealTime>
+        </SplitTime>
+      </SplitTimes>
+      <BestSegmentTime>
+        <RealTime>00:04:08.3302440</RealTime>
+      </BestSegmentTime>
+      <SegmentHistory>
+        <Time id="1">
+          <RealTime>00:04:08.3302440</RealTime>
+        </Time>
+      </SegmentHistory>
+    </Segment>
+    <Segment>
+      <Name>{Big Guac}</Name>
+      <Icon />
+      <SplitTimes>
+        <SplitTime name="Personal Best">
+          <RealTime>00:12:22.8767050</RealTime>
+        </SplitTime>
+      </SplitTimes>
+      <BestSegmentTime>
+        <RealTime>00:00:43.7524850</RealTime>
+      </BestSegmentTime>
+      <SegmentHistory>
+        <Time id="1">
+          <RealTime>00:00:43.7524850</RealTime>
+        </Time>
+      </SegmentHistory>
+    </Segment>
+  </Segments>
+  <AutoSplitterSettings />
+</Run>

--- a/spec/factories/run_files/livesplit_subsplit_ends_with_dash.lss
+++ b/spec/factories/run_files/livesplit_subsplit_ends_with_dash.lss
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Run version="1.7.0">
+  <GameIcon />
+  <GameName>El Tigre</GameName>
+  <CategoryName>Miracle City</CategoryName>
+  <Metadata>
+    <Run id="" />
+    <Platform usesEmulator="False">
+    </Platform>
+    <Region>
+    </Region>
+    <Variables />
+  </Metadata>
+  <Offset>00:00:00</Offset>
+  <AttemptCount>2</AttemptCount>
+  <AttemptHistory>
+    <Attempt id="1" started="10/20/2019 08:59:40" isStartedSynced="False" ended="10/20/2019 09:12:03" isEndedSynced="False">
+      <RealTime>00:12:22.8767050</RealTime>
+    </Attempt>
+  </AttemptHistory>
+  <Segments>
+    <Segment>
+      <Name>Piñata 1</Name>
+      <Icon />
+      <SplitTimes>
+        <SplitTime name="Personal Best">
+          <RealTime>00:03:36.8777640</RealTime>
+        </SplitTime>
+      </SplitTimes>
+      <BestSegmentTime>
+        <RealTime>00:03:36.8777640</RealTime>
+      </BestSegmentTime>
+      <SegmentHistory>
+        <Time id="1">
+          <RealTime>00:03:36.8777640</RealTime>
+        </Time>
+      </SegmentHistory>
+    </Segment>
+    <Segment>
+      <Name>Piñata 2</Name>
+      <Icon />
+      <SplitTimes>
+        <SplitTime name="Personal Best">
+          <RealTime>00:07:30.7939750</RealTime>
+        </SplitTime>
+      </SplitTimes>
+      <BestSegmentTime>
+        <RealTime>00:03:53.9162100</RealTime>
+      </BestSegmentTime>
+      <SegmentHistory>
+        <Time id="1">
+          <RealTime>00:03:53.9162100</RealTime>
+        </Time>
+      </SegmentHistory>
+    </Segment>
+    <Segment>
+      <Name>Piñata 3</Name>
+      <Icon />
+      <SplitTimes>
+        <SplitTime name="Personal Best">
+          <RealTime>00:11:39.1242190</RealTime>
+        </SplitTime>
+      </SplitTimes>
+      <BestSegmentTime>
+        <RealTime>00:04:08.3302440</RealTime>
+      </BestSegmentTime>
+      <SegmentHistory>
+        <Time id="1">
+          <RealTime>00:04:08.3302440</RealTime>
+        </Time>
+      </SegmentHistory>
+    </Segment>
+    <Segment>
+      <Name>-Big Guac</Name>
+      <Icon />
+      <SplitTimes>
+        <SplitTime name="Personal Best">
+          <RealTime>00:12:22.8767050</RealTime>
+        </SplitTime>
+      </SplitTimes>
+      <BestSegmentTime>
+        <RealTime>00:00:43.7524850</RealTime>
+      </BestSegmentTime>
+      <SegmentHistory>
+        <Time id="1">
+          <RealTime>00:00:43.7524850</RealTime>
+        </Time>
+      </SegmentHistory>
+    </Segment>
+  </Segments>
+  <AutoSplitterSettings />
+</Run>

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -626,6 +626,14 @@ describe Run, type: :model do
       groups = run.segments_with_groups
       expect(groups.length).to eq 53
     end
+
+    it 'ignores segments with dashes with no final subsplit' do
+      run = FactoryBot.create(:subsplits_ends_with_dash_run)
+      run.parse_into_db
+      run.reload
+      groups = run.segments_with_groups
+      expect(groups.length).to eq 4
+    end
   end
 
   context 'with nameless segments' do

--- a/spec/models/segment_group_spec.rb
+++ b/spec/models/segment_group_spec.rb
@@ -33,19 +33,22 @@ describe SegmentGroup, type: :model do
       run.segments << FactoryBot.create(:segment, run: run, segment_number: 3, name: '-Split 3')
       run.segments << FactoryBot.create(:segment, run: run, segment_number: 4, name: '-Split 4')
       run.segments << FactoryBot.create(:segment, run: run, segment_number: 5, name: 'Split 5')
+      run.segments << FactoryBot.create(:segment, run: run, segment_number: 6, name: '{Split 6}')
       run
     end
 
     it 'understands how to determine if a segment is a subsplit' do
-      segment_group = SegmentGroup.new(run, run.segments)
+      segment_group = SegmentGroup.new(run, run.segments[0..4])
       expect(segment_group.segments[0].subsplit?).to be true
       expect(segment_group.segments[0].last_subsplit?).to be false
       expect(segment_group.segments[4].last_subsplit?).to be true
+      expect(run.segments.last.subsplit?).to be false
     end
 
     it 'generates the correct display_name' do
-      segment_group = SegmentGroup.new(run, run.segments)
+      segment_group = SegmentGroup.new(run, run.segments[0..4])
       expect(segment_group.display_name).to eq('Split 5')
+      expect(run.segments.last.display_name).to eq('{Split 6}')
     end
   end
 end


### PR DESCRIPTION
Closes #640 

There were multiple issues related to what was mentioned in #640 

1. Segments with braces without anything after the braces were throwing an exception. The fix was to no longer think those are subsplits and just display their name as is (since that's what LiveSplit does).
1. `Run.segments_with_groups` was failing when it thought a segment group had only 1 segment (the dash example @glacials mentioned in #640). That is also fixed.

If your last split starts with a dash and is the only segment in a segment group will not display exactly as it does in LiveSplit, currently. In LiveSplit, it will show the dash. That is currently not happening, but it seems minor compared to the 500 errors.