### PR TITLE
Add affiliate links

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,10 +1,17 @@
 class SubscriptionsController < ApplicationController
   before_action :set_subscription, only: %i[update destroy]
 
+
   def index
   end
 
   def show
+    if params[:coupon]
+      Stripe::Subscription.update(
+        Subscription.find_by(stripe_session_id: params[:session_id]).stripe_subscription_id,
+        {coupon: params[:coupon]}
+      )
+    end
   end
 
   def update

--- a/app/javascript/stripe.js
+++ b/app/javascript/stripe.js
@@ -6,10 +6,12 @@ document.addEventListener('click', async function(event) {
 
   event.preventDefault()
 
+  const coupon = new URL(document.URL).searchParams.get('coupon')
+
   const stripe = Stripe(process.env.STRIPE_PUBLISHABLE_KEY)
   const result = await stripe.redirectToCheckout({
     items: [{plan: subscribeButton.dataset.planId, quantity: 1}],
-    successUrl: `${location.origin}/subscriptions/success?session_id={CHECKOUT_SESSION_ID}`,
+    successUrl: `${location.origin}/subscriptions/success?session_id={CHECKOUT_SESSION_ID}&coupon=${coupon}`,
     cancelUrl: `${location.origin}/subscriptions/cancel`,
     clientReferenceId: gon.user.id,
     customerEmail: gon.user.email,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,13 @@ Rails.application.routes.draw do
   delete '/settings/applications/:application',      to: 'applications#destroy'
   delete '/settings/authorizations/:application',    to: 'authorized_applications#destroy',                      as: :authorization
 
+  # partners is a map of partner special URLs to Stripe coupon IDs
+  {
+    test: 'H6Mbd83I',
+  }.each do |partner, stripe_coupon_id|
+    get "/#{partner}", to: redirect("/subscriptions?coupon=#{stripe_coupon_id}")
+  end
+
   get   '/subscriptions',         to: 'subscriptions#index',   as: :subscriptions
   get   '/subscriptions/success', to: 'subscriptions#show',    as: :subscription
   patch '/subscriptions',         to: 'subscriptions#update'


### PR DESCRIPTION
Adds an affiliate links feature to support upcoming partners. Navigate to splits.io/test, get redirected to the subscriptions page with a special code. If you sign up, the referring partner (test) will get a kickback.

This works by applying a Stripe Coupon, which will be tied 1-to-1 to a partner. We can later query against coupons to determine payouts.

Stripe Checkout, the pre-baked hosted checkout flow we use, apparently doesn't yet support Coupons. So we have to go through the Checkout flow without it then apply the Coupon afterwards.

This is decent if the Coupon isn't actually applying a meaningful discount (right now it's the minimum, $0.01), but if we long-term want to give users discounts as an incentive to use affiliate links, they'll still see full price in the Checkout flow (and be charged full price for the first month) so we'd probably want to find a better solution. Mostly hoping Stripe Checkout implements Coupon support before then, because I'm not all about building our own forms to take in credit card numbers.

Separately from that, using Coupons for this at all is very much MVP to test the idea; payouts will be manual vs. a solution like Stripe Connect (which _does_ integrate with Checkout, but we have to be accepted into the program) or a third party platform that integrates with Stripe to provide an affiliates product.