### PR TITLE
Rudimentary browser source layout for races

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -13,6 +13,7 @@
 @import article
 @import background
 @import brands
+@import browsersource
 @import carousel
 @import center
 @import cursor

--- a/app/assets/stylesheets/browsersource.sass
+++ b/app/assets/stylesheets/browsersource.sass
@@ -1,0 +1,7 @@
+.browsersource
+  background-color: black !important
+  border: #ff4136 1px solid !important
+  border-radius: 0.25rem !important
+  overflow: scroll !important
+  padding: 2em !important
+  resize: both !important

--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -9,10 +9,20 @@ class RacesController < ApplicationController
   end
 
   def show
+    if params[:browsersource] == '1'
+      render :browsersource_show
+      return
+    end
+
     return unless @race.abandoned? && !@race.secret_visibility?
 
     flash.now.alert = 'This race is abandoned and will not show up in listings! Interacting with it will list it again.'
   end
+
+  def race_params
+    params.permit(:join_token, :attachment, :browsersource)
+  end
+  helper_method :race_params
 
   private
 
@@ -37,10 +47,6 @@ class RacesController < ApplicationController
     }
   end
 
-  def race_params
-    params.permit(:join_token, :attachment)
-  end
-
   def set_race
     @race = Race.friendly_find!(params[:id])
   rescue ActiveRecord::RecordNotFound
@@ -51,7 +57,7 @@ class RacesController < ApplicationController
   # (public race or the user already joined).
   def shorten_url
     if @race.visibility == :public || @race.entries.find_for(current_user).present?
-      desired_fullpath = race_path(@race)
+      desired_fullpath = race_path(@race, race_params)
       redirect_to desired_fullpath if desired_fullpath != request.fullpath
       return
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -85,6 +85,10 @@ module ApplicationHelper
     'https://www.patreon.com/glacials'
   end
 
+  def discord_url
+    'https://discord.gg/yGaxX39'
+  end
+
   private
 
   def by(param)

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -168,4 +168,4 @@ html
                 span<> &bull;
                 a href=privacy_policy_path Privacy Policy
                 br
-                ' Copyright &copy; 2013 - #{Time.now.utc.year} Splits I/O, LLC
+                ' Copyright &copy; 2013 - #{Time.now.utc.year} Splits.io LLC

--- a/app/views/races/_title.slim
+++ b/app/views/races/_title.slim
@@ -62,6 +62,11 @@ race-title(
                   template v-if='loading' = render partial: 'shared/spinner'
                   template v-else-if='error' = icon('fas', 'times')
                   template v-else=true = icon('fas', 'check')
+          a.btn.btn-outline-light.btn-sm(
+            href=race_path(race, controller.race_params.merge(browsersource: 1))
+            title='View in browser source friendly layout (beta)'
+            v-tippy=true
+          ) = icon('fas', 'broadcast-tower')
           small.text-muted.mx-2 v-if='syncing'
             => render partial: 'shared/spinner'
             ' Syncing

--- a/app/views/races/browsersource_show.slim
+++ b/app/views/races/browsersource_show.slim
@@ -1,0 +1,76 @@
+- content_for(:title, @race)
+
+- content_for(:header) do
+  ol.breadcrumb.shadow
+    li.breadcrumb-item = link_to(site_title, root_path)
+    li.breadcrumb-item = link_to('Races', races_path)
+    li.breadcrumb-item.active = link_to(@race.to_param, race_path(@race))
+    li.breadcrumb-item.active = link_to('Browser source layout', race_path(@race, stream: 1))
+
+.col-md-8.mx-auto: .alert.alert-info
+  ' Welcome to the beta browser source layout for races!
+  ul
+    li You can resize each window from the bottom-right corner.
+    li The red borders are safe zones; no content will ever leave them.
+    li
+      ' You can edit or remove any text -- just select it and start typing -- but server changes will
+      ' overwrite your edits.
+  ' Please send any feedback to our
+  a> href=discord_url Discord server
+  ' or to
+  a href='mailto:hi@splits.io' hi@splits.io
+  = '. Thanks!'
+
+#vue-race.bg-black contenteditable=true
+  .text-center v-if="false" = render partial: 'shared/spinner'
+  race inline-template=true race-id=@race.id v-cloak=true
+    div
+      .text-center v-if="loading" = render partial: 'shared/spinner', locals: {message: 'Loading realtime race'}
+      div v-show="!loading"
+        .row.mx-2
+          #stats-box.col-md-6.browsersource = render partial: 'races/stats', locals: {race: @race}
+
+      .p-1
+        #entries-table.card.border.border-danger.browsersource
+          / Can't copy+paste this partial into this file because it would get replaced by Action Cable
+          = render partial: 'races/entries_table', locals: {race: @race}
+      .row.row-cols-1.row-cols-md-2.mx-0
+        .col.p-1
+          .card.browsersource
+            .list-group.list-group-flush
+              - unless @race.locked?
+                race-chat inline-template=true v-if='race' :race='race'
+                  .list-group-item#input-list-item.p-0.d-none
+                    = form_for(:chat, html: {onsubmit: 'event.preventDefault()'}) do |f|
+                      .input-group
+                        input.form-control#input-chat-text(
+                          autocomplete='off'
+                          autofocus=true
+                          disabled=current_user.nil?
+                          name='body'
+                          placeholder='Chat...'
+                          type='text'
+                          v-model='body'
+                        )
+                        .input-group-append
+                          button.btn.btn-dark#chat-submit(
+                            disabled=current_user.nil?
+                            type='submit'
+                            @click='chat'
+                            :disabled='body === ""'
+                            :title='error'
+                            v-tippy=true
+                          )
+                            template v-if='loading' = render partial: 'shared/spinner'
+                            span.text-danger v-else-if='error' => icon('fas', 'exclamation-triangle')
+                            template v-else=true => icon('fas', 'comment')
+              - @race.chat_messages.includes(user: [:twitch, :google]).order(created_at: :desc).each do |msg|
+                = render partial: 'chat_messages/show', locals: {chat_message: msg}
+              .list-group-item.p-0
+                .media
+                  img.mr-3 src=asset_path('logo-darkbg-breathingroom.png') width=25 height=25
+                  .media-body
+                    span.mr-2: .badge.badge-success Splits.io
+                    i Race created
+                    .float-right.pr-2
+                      = render partial: 'shared/relative_time', locals: {time: @race.created_at}


### PR DESCRIPTION
Adds a v1 browser source friendly layout for the race page. This is like the current race page, but:

1. Elements are resizeable by the user
2. Text is editable by the user
3. Elements have a black background with red borders and extra padding
4. UI that changes state is removed (can't chat, can't split, etc.)

The next item is to add a feed to this page with all the things we've talked about that could fuel interesting commentary during a race, but that part has some backend code and is worth its own branch.

Shoutouts to @jhobz for the red borders and padding suggestion and for spitballing the page with us :) 

<img width="343" alt="Screen Shot 2020-01-08 at 11 17 26" src="https://user-images.githubusercontent.com/438911/72008352-79094800-3208-11ea-8f53-5ec95286010a.png">

![localhost_3000_races_1_browsersource=1](https://user-images.githubusercontent.com/438911/72008097-f7b1b580-3207-11ea-962e-0f7bf9620a95.png)
