### PR TITLE
Fixes colors defined as CSS variables

### DIFF
--- a/app/assets/stylesheets/colors.sass
+++ b/app/assets/stylesheets/colors.sass
@@ -1,4 +1,4 @@
-root
+\:root
   --blue: rgba(14, 144, 210, 1)
   --purple: rgba(128, 87, 165, 1)
   --green: rgba(94, 185, 94, 1)


### PR DESCRIPTION
Closes #666 

The issue was the `root` selector was missing a `:` before it, so the variables weren't being set properly.

FWIW, there is an [issue at libsass](https://github.com/sass/libsass/issues/2511) regarding starting a selector with a `:`. It seems to work fine in SCSS files, but not SASS files. If they get around to fixing it, we'll probably have to remove the backslash.