### PR TITLE
Add an autosplitter badge

### DIFF
--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -3,7 +3,7 @@ module LikesHelper
 
   def tooltip(run)
     count = run.likes.count
-    return nil if count.zero?
+    return 'Like this run' if count.zero?
 
     likes = run.likes.joins(:user).limit(MAX_NAMES).pluck(:name)
 

--- a/app/models/concerns/unparsed_run.rb
+++ b/app/models/concerns/unparsed_run.rb
@@ -50,6 +50,7 @@ module UnparsedRun
           attempts:                run_data[:attempts],
           srdc_id:                 srdc_id || run_data[:metadata][:srdc_id],
           uses_emulator:           run_data[:metadata][:uses_emulator],
+          uses_autosplitter:       run_data[:autosplitter_settings].present?,
 
           realtime_duration_ms:    zero_to_nil(run_data[:realtime_duration_ms]),
           realtime_sum_of_best_ms: zero_to_nil(run_data[:realtime_sum_of_best_ms]),
@@ -95,6 +96,8 @@ module UnparsedRun
       run_data[:game_icon] = run.game_icon.presence
       run_data[:category]  = run.category_name
       run_data[:name]      = run.extended_name(false)
+
+      run_data[:autosplitter_settings] = run.auto_splitter_settings
 
       run_data[:metadata]                 = {}
       run_data[:metadata][:srdc_id]       = run.metadata.run_id.presence

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -143,7 +143,7 @@ html
           footer#footer
             = yield(:footer)
             .row
-              .col-md-6
+              .col-md-6.d-none.d-xl-block
                 - patrons = User.includes(:patreon, :twitch).joins(:patreon).where('patreon_users.pledge_cents >= 200')
                 - unless patrons.blank?
                   a> href=patreon_url

--- a/app/views/runs/_timing_badge.slim
+++ b/app/views/runs/_timing_badge.slim
@@ -3,7 +3,7 @@
     a.badge.badge-dark(
       href=run_path(run, params.permit(:compare).merge(timing: 'game'))
       v-tippy=true
-      :title='"Recorded in realtime & gametime—click to switch"'
+      title='Recorded in realtime & gametime—click to switch'
     )
       span.text-success => icon('fas', 'globe-americas')
       = icon('fas', 'gamepad')
@@ -11,7 +11,7 @@
     a.badge.badge-dark(
       href=run_path(run, params.permit(:compare).merge(timing: 'real'))
       v-tippy=true
-      :title='"Recorded in realtime & gametime—click to switch"'
+      title='Recorded in realtime & gametime—click to switch'
     )
       => icon('fas', 'globe-americas')
       span.text-success = icon('fas', 'gamepad')
@@ -20,5 +20,5 @@
     .badge v-tippy=true title='"Recorded in realtime"'
       = icon('fas', 'globe-americas')
   - if run.completed?(Run::GAME)
-    .badge v-tippy=true :title='"Recorded in gametime"'
+    .badge v-tippy=true title='Recorded in gametime'
       = icon('fas', 'gamepad')

--- a/app/views/runs/_timing_badge.slim
+++ b/app/views/runs/_timing_badge.slim
@@ -1,20 +1,24 @@
 - if run.completed?(Run::REAL) && run.completed?(Run::GAME)
   - if timing == Run::REAL
-    a.badge.badge-dark.tip(
-      title='Recorded in realtime & gametime — click to switch'
+    a.badge.badge-dark(
       href=run_path(run, params.permit(:compare).merge(timing: 'game'))
+      v-tippy=true
+      :title='"Recorded in realtime & gametime—click to switch"'
     )
       span.text-success => icon('fas', 'globe-americas')
       = icon('fas', 'gamepad')
   - if timing == Run::GAME
-    a.badge.badge-dark.tip(
-      title='Recorded in realtime & gametime — click to switch'
+    a.badge.badge-dark(
       href=run_path(run, params.permit(:compare).merge(timing: 'real'))
+      v-tippy=true
+      :title='"Recorded in realtime & gametime—click to switch"'
     )
       => icon('fas', 'globe-americas')
       span.text-success = icon('fas', 'gamepad')
 - else
   - if run.completed?(Run::REAL)
-    .badge.tip title='Recorded in realtime' = icon('fas', 'globe-americas')
+    .badge v-tippy=true title='"Recorded in realtime"'
+      = icon('fas', 'globe-americas')
   - if run.completed?(Run::GAME)
-    .badge.tip title='Recorded in gametime' = icon('fas', 'gamepad')
+    .badge v-tippy=true :title='"Recorded in gametime"'
+      = icon('fas', 'gamepad')

--- a/app/views/runs/_title.slim
+++ b/app/views/runs/_title.slim
@@ -16,23 +16,23 @@ h5
       - old_runs.each do |old_run|
         a.dropdown-item href=run_path(old_run) = old_run.duration.format
   - if run.srdc_id.present?
-    a.badge.badge-dark.mr-2 href=run.srdc_url v-tippy=true :title='"See on Speedrun.com"'
+    a.badge.badge-dark.mr-2 href=run.srdc_url v-tippy=true title='See on Speedrun.com'
       = image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
   - if run.entry.present? && !run.entry.ghost?
-    a.badge.badge-dark.mr-2 v-tippy=true href=race_path(run.entry.race) :title='"Recorded as part of a race"'
+    a.badge.badge-dark.mr-2 v-tippy=true href=race_path(run.entry.race) title='Recorded as part of a race'
       = icon('fas', 'flag-checkered')
   - if run.video&.supports_embedding?
     - if run.video.youtube?
-      a.badge.badge-dark.mr-2 href=run.video.url v-tippy=true :title="'Watch on YouTube"'
+      a.badge.badge-dark.mr-2 href=run.video.url v-tippy=true title='Watch on YouTube'
         => icon('fab', 'youtube')
     - elsif !run.video.twitch?
-      a.badge.badge-dark.mr-2 href=run.video.url v-tippy=true :title='"Watch video"'
+      a.badge.badge-dark.mr-2 href=run.video.url v-tippy=true title='Watch video'
         => icon('fas', 'video')
   - if run.in_progress?(timing)
-    a.badge.p-0.mr-2 v-tippy=true :title='"In progress"'
+    a.badge.p-0.mr-2 v-tippy=true title='In progress'
       .text-danger = icon('fas', 'satellite-dish')
   - if run.uses_autosplitter?
-    .badge.mr-2 v-tippy=true :title='"Used an autosplitter"' = icon('fas', 'magic')
+    .badge.mr-2 v-tippy=true title='Used an autosplitter' = icon('fas', 'magic')
 
 .btn-toolbar.mb-2 role='toolbar' aria={label: 'Run navigation'}
   .btn-group.m-2 role='group' aria={label: 'Run navigation'}
@@ -55,19 +55,19 @@ h5
             => icon('fas', 'user-check')
             ' Claim
         - else
-          button.btn.btn-outline-secondary.disabled v-tippy=true style='cursor: default' :title='"Sign in to claim"'
+          button.btn.btn-outline-secondary.disabled v-tippy=true style='cursor: default' title='Sign in to claim'
             ' Claim
   - if can?(:create, RunLike)
     .btn-group.m-2: button#like-button.btn(
       data={liked: current_user.likes?(run) ? '1' : '0'}
       class=(current_user.likes?(run) ? 'btn-dark' : 'btn-outline-light')
       v-tippy=true
-      :title="'#{tooltip(run)}'"
+      title=tooltip(run)
     )
       ' 🎉
       span#likes-count data={value: run.likes.count} = run.likes.count
   - else
-    .btn-group.m-2: .btn.btn-outline-secondary.disabled v-tippy=true :title="'#{tooltip(run)}'"
+    .btn-group.m-2: .btn.btn-outline-secondary.disabled v-tippy=true title=tooltip(run)
       ' 🎉
       = run.likes.count
   - if run.belongs_to?(current_user)
@@ -78,7 +78,7 @@ h5
           href='#'
           data={toggle: :modal, target: current_user.srdc ? '#srdc-submit' : '#srdc-link'}
           v-tippy=true
-          :title='"Automatically submit to Speedrun.com. You will get a chance to review the details first."'
+          title='Automatically submit to Speedrun.com. You will get a chance to review the details first.'
         )
           => image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
           span Auto-submit

--- a/app/views/runs/_title.slim
+++ b/app/views/runs/_title.slim
@@ -16,19 +16,23 @@ h5
       - old_runs.each do |old_run|
         a.dropdown-item href=run_path(old_run) = old_run.duration.format
   - if run.srdc_id.present?
-    a.badge.badge-dark.tip.mr-2 title='See on Speedrun.com' href=run.srdc_url
+    a.badge.badge-dark.mr-2 href=run.srdc_url v-tippy=true :title='"See on Speedrun.com"'
       = image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
   - if run.entry.present? && !run.entry.ghost?
-    a.badge.badge-dark.tip.mr-2 title='Recorded as part of a race' href=race_path(run.entry.race)
+    a.badge.badge-dark.mr-2 v-tippy=true href=race_path(run.entry.race) :title='"Recorded as part of a race"'
       = icon('fas', 'flag-checkered')
   - if run.video&.supports_embedding?
     - if run.video.youtube?
-      a.badge.badge-dark.tip.mr-2 href=run.video.url title='Watch on YouTube' => icon('fab', 'youtube')
+      a.badge.badge-dark.mr-2 href=run.video.url v-tippy=true :title="'Watch on YouTube"'
+        => icon('fab', 'youtube')
     - elsif !run.video.twitch?
-      a.badge.badge-dark.tip.mr-2 href=run.video.url title='Watch video' => icon('fas', 'video')
+      a.badge.badge-dark.mr-2 href=run.video.url v-tippy=true :title='"Watch video"'
+        => icon('fas', 'video')
   - if run.in_progress?(timing)
-    a.badge.tip.p-0.mr-2 title='In progress'
+    a.badge.p-0.mr-2 v-tippy=true :title='"In progress"'
       .text-danger = icon('fas', 'satellite-dish')
+  - if run.uses_autosplitter?
+    .badge.mr-2 v-tippy=true :title='"Used an autosplitter"' = icon('fas', 'magic')
 
 .btn-toolbar.mb-2 role='toolbar' aria={label: 'Run navigation'}
   .btn-group.m-2 role='group' aria={label: 'Run navigation'}
@@ -49,29 +53,32 @@ h5
         - if current_user.present?
           a#claim-nav-link.btn.btn-outline-success href='#' data-confirm="Claim this run as #{current_user}?"
             => icon('fas', 'user-check')
-            span Claim
+            ' Claim
         - else
-          button.btn.btn-outline-secondary.tip.disabled title='Sign in to claim' style='cursor: default' Claim
+          button.btn.btn-outline-secondary.disabled v-tippy=true style='cursor: default' :title='"Sign in to claim"'
+            ' Claim
   - if can?(:create, RunLike)
-    .btn-group.m-2: button#like-button.btn.tip(
+    .btn-group.m-2: button#like-button.btn(
       data={liked: current_user.likes?(run) ? '1' : '0'}
       class=(current_user.likes?(run) ? 'btn-dark' : 'btn-outline-light')
-      title=tooltip(run)
+      v-tippy=true
+      :title="'#{tooltip(run)}'"
     )
       ' 🎉
       span#likes-count data={value: run.likes.count} = run.likes.count
   - else
-    .btn-group.m-2: .btn.btn-outline-secondary.tip.disabled title=tooltip(run)
+    .btn-group.m-2: .btn.btn-outline-secondary.disabled v-tippy=true :title="'#{tooltip(run)}'"
       ' 🎉
       = run.likes.count
   - if run.belongs_to?(current_user)
     .btn-group.m-2 role='group' aria={label: 'Calls to action'}
       = render 'highlight_button', run: run
       - if run.category&.srdc && run.srdc_id.blank?
-        a.btn.btn-srdc.tip-top(
+        a.btn.btn-srdc(
           href='#'
           data={toggle: :modal, target: current_user.srdc ? '#srdc-submit' : '#srdc-link'}
-          title="Automatically submit to Speedrun.com. You'll get a chance to review the details first."
+          v-tippy=true
+          :title='"Automatically submit to Speedrun.com. You will get a chance to review the details first."'
         )
           => image_tag(asset_path('srdc.png'), style: 'height: 0.8em')
           span Auto-submit

--- a/db/migrate/20200207203633_add_uses_autosplitter_to_runs.rb
+++ b/db/migrate/20200207203633_add_uses_autosplitter_to_runs.rb
@@ -1,0 +1,5 @@
+class AddUsesAutosplitterToRuns < ActiveRecord::Migration[6.0]
+  def change
+    add_column :runs, :uses_autosplitter, :bool, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_14_184419) do
+ActiveRecord::Schema.define(version: 2020_02_07_203633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -290,6 +290,7 @@ ActiveRecord::Schema.define(version: 2020_01_14_184419) do
     t.boolean "uses_emulator", default: false
     t.uuid "speedrun_dot_com_platform_id"
     t.uuid "speedrun_dot_com_region_id"
+    t.boolean "uses_autosplitter"
     t.index ["category_id"], name: "index_runs_on_category_id"
     t.index ["s3_filename"], name: "index_runs_on_s3_filename"
     t.index ["user_id"], name: "index_runs_on_user_id"


### PR DESCRIPTION
Adds a badge to runs that were performed using an autosplitter:

<img width="412" alt="Screen Shot 2020-02-07 at 13 04 30" src="https://user-images.githubusercontent.com/438911/74065737-6a9a8180-49aa-11ea-9e49-84427eac9437.png">

I had trouble with the tooltip even after hard loads, so I dove a bit into solving them globally -- now that our whole site is in a Vue app container, even if we're not using Vue in a given place we can still take advantage of the Vue tippy tooltips, which show consistently regardless of soft/hard loads, so I moved the surrounding tooltips over to that style.