### PR TITLE
Rename Splits I/O to Splits.io in a lot of places

### DIFF
--- a/app/assets/images/favicon/README.md
+++ b/app/assets/images/favicon/README.md
@@ -18,8 +18,8 @@ Insert the following code in the `head` section of your pages:
     <link rel="manifest" href="/Dfv87ZbNh2/site.webmanifest">
     <link rel="mask-icon" href="/Dfv87ZbNh2/safari-pinned-tab.svg" color="#292b30">
     <link rel="shortcut icon" href="/Dfv87ZbNh2/favicon.ico">
-    <meta name="apple-mobile-web-app-title" content="Splits I/O">
-    <meta name="application-name" content="Splits I/O">
+    <meta name="apple-mobile-web-app-title" content="Splits.io">
+    <meta name="application-name" content="Splits.io">
     <meta name="msapplication-TileColor" content="#603cba">
     <meta name="msapplication-config" content="/Dfv87ZbNh2/browserconfig.xml">
     <meta name="theme-color" content="#292b30">

--- a/app/assets/images/favicon/html_code.html
+++ b/app/assets/images/favicon/html_code.html
@@ -6,8 +6,8 @@
 <link rel="manifest" href="/Dfv87ZbNh2/site.webmanifest">
 <link rel="mask-icon" href="/Dfv87ZbNh2/safari-pinned-tab.svg" color="#292b30">
 <link rel="shortcut icon" href="/Dfv87ZbNh2/favicon.ico">
-<meta name="apple-mobile-web-app-title" content="Splits I/O">
-<meta name="application-name" content="Splits I/O">
+<meta name="apple-mobile-web-app-title" content="Splits.io">
+<meta name="application-name" content="Splits.io">
 <meta name="msapplication-TileColor" content="#603cba">
 <meta name="msapplication-config" content="/Dfv87ZbNh2/browserconfig.xml">
 <meta name="theme-color" content="#292b30">

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -75,7 +75,7 @@ class Game < ApplicationRecord
   end
 
   # merge_into! moves all categories, aliases, and runs over to the given game, then destroys this game. Use this when
-  # there are two Splits I/O games representing the same game, like "Tron Evolution" and "Tron: Evolution".
+  # there are two Splits.io games representing the same game, like "Tron Evolution" and "Tron: Evolution".
   def merge_into!(game)
     ApplicationRecord.transaction do
       aliases.update_all(game_id: game.id)

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -149,7 +149,7 @@ class Run < ApplicationRecord
   end
 
   # If we don't have a user assigned but we do have a speedrun.com run assigned, try to fetch the user from
-  # speedrun.com. For this to work that user must have their Twitch account tied to both Splits I/O and speedrun.com.
+  # speedrun.com. For this to work that user must have their Twitch account tied to both Splits.io and speedrun.com.
   def discover_runner
     return if user.present?
 

--- a/app/views/doorkeeper/authorizations/new.slim
+++ b/app/views/doorkeeper/authorizations/new.slim
@@ -14,7 +14,7 @@
             p: h4.text-primary = @pre_auth.client.name
             p: span is requesting these abilities:
             p: ol
-                li See who you are on Splits I/O
+                li See who you are on Splits.io
                 - @pre_auth.scope.split(' ').each do |scope|
                   li = scope_to_sentence(scope)
             p You can always revoke these permissions later.

--- a/app/views/pages/read_only_mode.slim
+++ b/app/views/pages/read_only_mode.slim
@@ -5,7 +5,7 @@ article
       .card
         .card-header.bg-warning.text-white Read-Only Mode
         .card-body
-          p Splits I/O is temporarily in read-only mode for a database upgrade. This started at 7pm GMT (12pm PST) and is
+          p Splits.io is temporarily in read-only mode for a database upgrade. This started at 7pm GMT (12pm PST) and is
             expected to last 1 hour.
           p You can browse the site, but run uploads, edits, logging in/out, and other features that modify the database
             will fail.

--- a/app/views/why/darkmode.slim
+++ b/app/views/why/darkmode.slim
@@ -5,7 +5,7 @@
 article
   .question
     p
-      | If you never noticed before, Splits I/O has had a darkmode
+      | If you never noticed before, Splits.io has had a darkmode
       a< href='https://github.com/glacials/splits-io/issues/72' since 2015
       | . You could turn it on and off from the footer. It was great.
     p Except it wasn't. I always develop in lightmode because that's how I wrote the site (for no reason other than

--- a/app/views/why/permalinks.slim
+++ b/app/views/why/permalinks.slim
@@ -23,7 +23,7 @@ article
          code = '(64^1) + (64^2) + (64^3) = 266 304'
          span< URLs that we can get from one-, two-, and three-character URLs.
       li Having just one form of identification for a run, like a not-crazy person would do, makes some API stuff that
-         I've been wanting to do a bit simpler. That API stuff will in turn let programs access Splits I/O in a less
+         I've been wanting to do a bit simpler. That API stuff will in turn let programs access Splits.io in a less
          volatile fashion than they have to right now.
       li In general, complexity where there doesn't need to be any is bad.
     p

--- a/app/views/why/readonly.slim
+++ b/app/views/why/readonly.slim
@@ -6,7 +6,7 @@ article
   .row
     .col-lg-8
       p Today the site went into read-only mode for planned maintenance for about an hour.
-      p The root goal for this maintenance is to make it easier to work with segments and segment history in Splits I/O's
+      p The root goal for this maintenance is to make it easier to work with segments and segment history in Splits.io's
         code base.
       p To make it easier to work with segments and segment histories, we're changing from storing them in DynamoDB to
         storing them in ActiveRecord (PostgreSQL), which is how Ruby on Rails wants you to store your data.

--- a/lib/programs/face_split.rb
+++ b/lib/programs/face_split.rb
@@ -23,7 +23,7 @@ module Programs::FaceSplit
     false
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/floating_speedrun_timer.rb
+++ b/lib/programs/floating_speedrun_timer.rb
@@ -23,7 +23,7 @@ module Programs::FloatingSpeedrunTimer
     false
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     true

--- a/lib/programs/frame_perfect.rb
+++ b/lib/programs/frame_perfect.rb
@@ -23,7 +23,7 @@ module Programs::FramePerfect
     false
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     true

--- a/lib/programs/llanfair.rb
+++ b/lib/programs/llanfair.rb
@@ -23,7 +23,7 @@ module Programs::Llanfair
     false
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/llanfair2.rb
+++ b/lib/programs/llanfair2.rb
@@ -23,7 +23,7 @@ module Programs::Llanfair2
     false
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/llanfair_gered.rb
+++ b/lib/programs/llanfair_gered.rb
@@ -23,7 +23,7 @@ module Programs::LlanfairGered
     true
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/portal_2_live_timer.rb
+++ b/lib/programs/portal_2_live_timer.rb
@@ -23,7 +23,7 @@ module Programs::Portal2LiveTimer
     false
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/shit_split.rb
+++ b/lib/programs/shit_split.rb
@@ -23,7 +23,7 @@ module Programs::ShitSplit
     false
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/source_live_timer.rb
+++ b/lib/programs/source_live_timer.rb
@@ -23,7 +23,7 @@ module Programs::SourceLiveTimer
     false
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/splitterz.rb
+++ b/lib/programs/splitterz.rb
@@ -26,7 +26,7 @@ module Programs::SplitterZ
     true
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/splitty.rb
+++ b/lib/programs/splitty.rb
@@ -23,7 +23,7 @@ module Programs::Splitty
     false
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/time_split_tracker.rb
+++ b/lib/programs/time_split_tracker.rb
@@ -23,7 +23,7 @@ module Programs::TimeSplitTracker
     true
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/urn.rb
+++ b/lib/programs/urn.rb
@@ -23,7 +23,7 @@ module Programs::Urn
     true
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/worstrun.rb
+++ b/lib/programs/worstrun.rb
@@ -23,7 +23,7 @@ module Programs::Worstrun
     false
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/lib/programs/wsplit.rb
+++ b/lib/programs/wsplit.rb
@@ -26,7 +26,7 @@ module Programs::WSplit
     true
   end
 
-  # exchangeable? is true if the timer supports the Splits I/O Exchange Format for importing and exporting, false
+  # exchangeable? is true if the timer supports the Splits.io Exchange Format for importing and exporting, false
   # otherwise. See: https://github.com/glacials/splits-io/tree/master/public/schema
   def self.exchangeable?
     false

--- a/public/422.html
+++ b/public/422.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>splits i/o - 422 error</title>
+    <title>Splits.io - 422 error</title>
   </head>
   <body>
     <pre>

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -16,7 +16,7 @@ this file proves authorship, not property.
 
   CryZe107 and wooferzfg
   for not using a proprietary format when making LiveSplit; also for open sourcing it when i complained enough
-  Twitter: @cryze107, @wooferzfg1
+  Twitter: @cryze107, @wooferzfg
 
   batedurgonnadie
   for being the first major consumer of the api, and for being a far more effective error reporter than rollbar

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -23,7 +23,7 @@ this file proves authorship, not property.
   Twitter: @batedurgonnadie
 
   my senior project teacher from school
-  for understanding my dislike for my senior project (splitsdb) and letting me rebuild it for web class (into Splits I/O)
+  for understanding my dislike for my senior project (splitsdb) and letting me rebuild it for web class (into Splits.io)
 
   a lot of people
   for seeing an error saying to email me then actually emailing me :)

--- a/public/schema/run_v1.0.0.json
+++ b/public/schema/run_v1.0.0.json
@@ -2,8 +2,8 @@
   "$id": "https://splits.io/schema/run_v1.0.0.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "title": "Splits I/O JSON Schema",
-  "description": "Splits I/O JSON Schema is a specification for the transmission of runs between services and programs.",
+  "title": "Splits.io JSON Schema",
+  "description": "Splits.io JSON Schema is a specification for the transmission of runs between services and programs.",
   "required": ["_schemaVersion", "timer"],
   "additionalProperties": false,
   "definitions": {
@@ -59,8 +59,8 @@
   "properties": {
     "_schemaVersion": {
       "type": "string",
-      "title": "Splits I/O JSON Schema Version",
-      "description": "Schema Version specifies which version of the Splits I/O JSON Schema is being used. This schema specifies only v1.0.0.",
+      "title": "Splits.io JSON Schema Version",
+      "description": "Schema Version specifies which version of the Splits.io JSON Schema is being used. This schema specifies only v1.0.0.",
       "examples": "v1.0.0",
       "const": "v1.0.0"
     },
@@ -78,8 +78,8 @@
         },
         "splitsioID": {
           "type": "string",
-          "title": "Splits I/O ID",
-          "description": "Splits I/O ID is the run's ID on Splits I/O. This can be used to communicate with the Splits I/O API.",
+          "title": "Splits.io ID",
+          "description": "Splits.io ID is the run's ID on Splits.io. This can be used to communicate with the Splits.io API.",
           "examples": ["oqt"]
         }
       }
@@ -239,8 +239,8 @@
           "properties": {
             "splitsioID": {
               "type": "string",
-              "title": "Splits I/O ID",
-              "description": "Splits I/O ID specifies the game's Splits I/O ID.",
+              "title": "Splits.io ID",
+              "description": "Splits.io ID specifies the game's Splits.io ID.",
               "examples": ["234"]
             },
             "speedruncomID": {
@@ -281,8 +281,8 @@
           "properties": {
             "splitsioID": {
               "type": "string",
-              "title": "Splits I/O ID",
-              "description": "Splits I/O ID specifies the category's Splits I/O ID.",
+              "title": "Splits.io ID",
+              "description": "Splits.io ID specifies the category's Splits.io ID.",
               "examples": ["234"]
             },
             "speedruncomID": {
@@ -334,8 +334,8 @@
               },
               "splitsioID": {
                 "type": "string",
-                "title": "Splits I/O ID",
-                "description": "Splits I/O ID specifies the runner's Splits I/O ID.",
+                "title": "Splits.io ID",
+                "description": "Splits.io ID specifies the runner's Splits.io ID.",
                 "examples": ["234"]
               },
               "speedruncomID": {

--- a/scripts/lambda/parse/package.json
+++ b/scripts/lambda/parse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "splitsio-lambda",
   "repository": "glacials/splits-io",
-  "description": "An AWS Lambda job for Splits I/O",
+  "description": "An AWS Lambda job for Splits.io",
   "license": "MIT",
   "main": "index.js",
   "scripts": {

--- a/scripts/lambda/rollbar-deploy/README.md
+++ b/scripts/lambda/rollbar-deploy/README.md
@@ -1,4 +1,4 @@
-# Splits I/O Rollbar Deploy Job
+# Splits.io Rollbar Deploy Job
 This is an AWS Lambda job which is triggered automatically by AWS CodePipeline when a deploy to production happens. It
 then hits an endpoint in Rollbar that tells it the revision hash for the deployed commit, so that Rollbar can smartly
 link directly to error-causing lines in GitHub.

--- a/scripts/lambda/rollbar-deploy/package.json
+++ b/scripts/lambda/rollbar-deploy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "splitsio-rollbar-deploy",
   "repository": "glacials/splits-io",
-  "description": "An AWS Lambda job for Splits I/O",
+  "description": "An AWS Lambda job for Splits.io",
   "license": "MIT",
   "main": "index.js",
   "scripts": {

--- a/spec/controllers/runs/exports_controller_spec.rb
+++ b/spec/controllers/runs/exports_controller_spec.rb
@@ -21,7 +21,7 @@ describe Runs::ExportsController do
     let(:run) { FactoryBot.create(:run, :parsed) }
     let(:response) { get(:timer, params: {run: run.id36, timer: timer}) }
 
-    context 'as the Splits I/O Exchange Format' do
+    context 'as the Splits.io Exchange Format' do
       let(:timer) { 'exchange' }
 
       it 'returns a 200' do

--- a/spec/views/runs/exports_spec.rb
+++ b/spec/views/runs/exports_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'runs/exports/exchange' do
-  it 'renders the Splits I/O Exchange Format template' do
+  it 'renders the Splits.io Exchange Format template' do
     assign(:run, FactoryBot.create(:run, :parsed))
     render
 


### PR DESCRIPTION
I excluded changes to the name of the company in the privacy policy and also any changes to the API v3 docs.