### PR TITLE
Fix `realtime_shortest_duration_ms` in API Schema

### DIFF
--- a/spec/support/models/api/v4/segment.json
+++ b/spec/support/models/api/v4/segment.json
@@ -48,8 +48,10 @@
       "minimum": 0
     },
     "realtime_shortest_duration_ms": {
-      "type": "number",
-      "minimum": 0
+      "type": [
+        "number",
+        "null"
+      ]
     },
     "realtime_gold": {
       "type": "boolean"


### PR DESCRIPTION
Turns out that it can indeed be null, as can be seen in this request: https://splits.io/api/v4/runs/4yrb