### PR TITLE
Change the categories/runners endpoint to return unique runners

### DIFF
--- a/app/controllers/api/v4/categories/runners_controller.rb
+++ b/app/controllers/api/v4/categories/runners_controller.rb
@@ -2,6 +2,6 @@ class Api::V4::Categories::RunnersController < Api::V4::ApplicationController
   before_action :set_category, only: [:index]
 
   def index
-    render json: Api::V4::UserBlueprint.render(@category.users, root: :runners)
+    render json: Api::V4::UserBlueprint.render(@category.runners, root: :runners)
   end
 end

--- a/spec/controllers/api/v4/categories/runners_controller_spec.rb
+++ b/spec/controllers/api/v4/categories/runners_controller_spec.rb
@@ -13,6 +13,13 @@ describe Api::V4::Categories::RunnersController do
       it 'renders a runner schema' do
         expect(subject.body).to match_json_schema(:category_runners)
       end
+
+      it "doesn't render a runner more than once" do
+        create(:run, :owned, category: category, user: Run.last.user)
+        body = JSON.parse(subject.body)
+        runner_ids = body["runners"].map { |runner| runner["id"] }
+        expect(runner_ids.length).to eq runner_ids.uniq.length
+      end
     end
 
     context 'for a nonexisting category' do


### PR DESCRIPTION
Closes #689 

Previously, the endpoint was calling `category.users` which is just all the users through runs of a category. `category.runners` already exists and goes through a scope on `User` that is the same thing with a `distinct` tacked on. So, it's the exact thing that is desired.