### PR TITLE
Compare against sum of bests

### DIFF
--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -124,7 +124,7 @@ class RunsController < ApplicationController
       default_timing: @run.default_timing,
     }
 
-    @compare_runs = Run.where(id: (params[:compare] || '').split(',').map { |r| r.to_i(36) })
+    @compare_runs = Run.where(id: (params[:compare] || '').split(',').map { |r| r.to_i(36) }) + SumOfBestRun.where(id: (params[:sum_of_best] || '').split(',').map { |r| r.to_i(36) })
     gon.compare_runs = @compare_runs.map { |run| {id: run.id36} }
 
     gon.run['user'] = if @run.user.nil?

--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -125,7 +125,7 @@ class RunsController < ApplicationController
     }
 
     @compare_runs = Run.where(id: (params[:compare] || '').split(',').map { |r| r.to_i(36) }) + SumOfBestRun.where(id: (params[:sum_of_best] || '').split(',').map { |r| r.to_i(36) })
-    gon.compare_runs = @compare_runs.map { |run| {id: run.id36} }
+    gon.compare_runs = @compare_runs.reject { |run| run.is_a?(SumOfBestRun) }.map { |run| {id: run.id36} }
 
     gon.run['user'] = if @run.user.nil?
                         nil

--- a/app/javascript/chart_builder.js
+++ b/app/javascript/chart_builder.js
@@ -20,7 +20,7 @@ document.addEventListener('turbolinks:load', function() {
     headers: {accept: 'application/json'}
   }))
 
-  if (gon.compare_runs !== undefined) {
+  if (false && gon.compare_runs !== undefined) {
     gon.compare_runs.forEach(run => runs.push(fetch(`/api/v4/runs/${run.id}?historic=1&segment_groups=1`, {
       headers: {accept: 'application/json'}
     })))

--- a/app/javascript/chart_builder.js
+++ b/app/javascript/chart_builder.js
@@ -20,7 +20,7 @@ document.addEventListener('turbolinks:load', function() {
     headers: {accept: 'application/json'}
   }))
 
-  if (false && gon.compare_runs !== undefined) {
+  if (gon.compare_runs !== undefined) {
     gon.compare_runs.forEach(run => runs.push(fetch(`/api/v4/runs/${run.id}?historic=1&segment_groups=1`, {
       headers: {accept: 'application/json'}
     })))

--- a/app/models/sum_of_best_run.rb
+++ b/app/models/sum_of_best_run.rb
@@ -60,6 +60,10 @@ class SumOfBestRun
     end
   end
 
+  def video
+    nil
+  end
+
   def self.where(params)
     Run.where(params).map { |run| SumOfBestRun.new(run) }
   end

--- a/app/models/sum_of_best_run.rb
+++ b/app/models/sum_of_best_run.rb
@@ -1,0 +1,66 @@
+class SumOfBestRun
+  include CompletedRun
+
+  attr_accessor :id, :id36, :run
+
+  delegate_missing_to :@run
+
+  def initialize(original_run)
+    self.id = original_run.id
+    self.id36 = "#{original_run.id36}-sum-of-best"
+    self.run = original_run
+    # self.run.segments = segments_from(original_run)
+    self.run.segments.each do |segment|
+      segment.gametime_duration_ms = segment.gametime_shortest_duration_ms
+      segment.realtime_duration_ms = segment.realtime_shortest_duration_ms
+    end
+
+  end
+
+  def gametime_duration_ms
+    @gametime_duration_ms ||= segments.sum(&:gametime_duration_ms)
+  end
+
+  def realtime_duration_ms
+    @realtime_duration_ms ||= segments.sum(&:realtime_duration_ms)
+  end
+
+  # def segments_from(original_run)
+  #   return @segments if @segments
+  #   @segments = original_run.segments.dup
+  #   @segments.to_a.map! do |segment|
+  #     segment.gametime_duration_ms = segment.gametime_shortest_duration_ms
+  #     segment.realtime_duration_ms = segment.realtime_shortest_duration_ms
+  #     segment
+  #   end
+  # end
+
+  def segments_with_groups
+    return @segments_with_groups if @segments_with_groups
+    segment_game_end_time = 0
+    segment_real_end_time = 0
+    @segments_with_groups = run.segments_with_groups
+    @segments_with_groups.map! do |segment_or_group|
+      if segment_or_group.is_a?(Segment)
+        segment_or_group.gametime_duration_ms = segment_or_group.gametime_shortest_duration_ms
+        segment_or_group.realtime_duration_ms = segment_or_group.realtime_shortest_duration_ms
+        segment_or_group
+      elsif segment_or_group.is_a?(SegmentGroup)
+        segment_or_group.segments.map! do |segment|
+          segment.gametime_duration_ms = segment.gametime_shortest_duration_ms
+          segment.realtime_duration_ms = segment.realtime_shortest_duration_ms
+          segment_game_end_time += segment.gametime_duration_ms
+          segment_real_end_time += segment.realtime_duration_ms
+          segment.gametime_end_ms = segment_game_end_time
+          segment.realtime_end_ms = segment_real_end_time
+          segment
+        end
+        segment_or_group
+      end
+    end
+  end
+
+  def self.where(params)
+    Run.where(params).map { |run| SumOfBestRun.new(run) }
+  end
+end

--- a/app/models/sum_of_best_run.rb
+++ b/app/models/sum_of_best_run.rb
@@ -14,7 +14,8 @@ class SumOfBestRun
       segment.gametime_duration_ms = segment.gametime_shortest_duration_ms
       segment.realtime_duration_ms = segment.realtime_shortest_duration_ms
     end
-
+    self.run.gametime_duration_ms = gametime_duration_ms
+    self.run.realtime_duration_ms = realtime_duration_ms
   end
 
   def gametime_duration_ms

--- a/app/models/sum_of_best_run.rb
+++ b/app/models/sum_of_best_run.rb
@@ -9,7 +9,6 @@ class SumOfBestRun
     self.id = original_run.id
     self.id36 = "#{original_run.id36}-sum-of-best"
     self.run = original_run
-    # self.run.segments = segments_from(original_run)
     self.run.segments.each do |segment|
       segment.gametime_duration_ms = segment.gametime_shortest_duration_ms
       segment.realtime_duration_ms = segment.realtime_shortest_duration_ms
@@ -25,16 +24,6 @@ class SumOfBestRun
   def realtime_duration_ms
     @realtime_duration_ms ||= segments.sum(&:realtime_duration_ms)
   end
-
-  # def segments_from(original_run)
-  #   return @segments if @segments
-  #   @segments = original_run.segments.dup
-  #   @segments.to_a.map! do |segment|
-  #     segment.gametime_duration_ms = segment.gametime_shortest_duration_ms
-  #     segment.realtime_duration_ms = segment.realtime_shortest_duration_ms
-  #     segment
-  #   end
-  # end
 
   def segments_with_groups
     return @segments_with_groups if @segments_with_groups

--- a/app/views/runs/_compare_button.slim
+++ b/app/views/runs/_compare_button.slim
@@ -44,11 +44,12 @@
                 span content='Twitch highlight attached' v-tippy=true =< icon('fab', 'twitch')
     - if compare_runs.any?
       .btn-group.ml-1
-        a.btn.px-1(
-          content='Swap comparison'
-          href=run_path(compare_runs.first, params.permit(:timing).merge(compare: run))
-          v-tippy=true
-        ) = icon('fas', 'exchange-alt')
+        - if compare_runs.all? { |run| !run.is_a?(SumOfBestRun) }
+          a.btn.px-1(
+            content='Swap comparison'
+            href=run_path(compare_runs.first, params.permit(:timing).merge(compare: run))
+            v-tippy=true
+          ) = icon('fas', 'exchange-alt')
         a.btn.px-1(
           content='Remove comparison'
           href=run_path(run, params.permit(:timing).delete(:compare))

--- a/app/views/runs/_compare_button.slim
+++ b/app/views/runs/_compare_button.slim
@@ -15,6 +15,9 @@
     .dropdown-menu aria={labelledby: 'compare'} style='height: auto; max-height: 400px; overflow-x: hidden'
         .dropdown-header Mine
         - comparable_runs = current_user.present? ? current_user.comparable_runs(timing, run).where.not(id: run.id) : []
+        - sum_of_best_run = SumOfBestRun.where(id: run.id).first
+        a.dropdown-item href=run_path(run, params.permit(:timing).merge(sum_of_best: run.id))
+          = "#{sum_of_best_run.duration(timing).format} - Your Sum of Best"
         - if comparable_runs.none?
           .dropdown-item.disabled: i No comparable runs by me
         - comparable_runs.each do |comparable_run|

--- a/app/views/runs/_gold_timeline.slim
+++ b/app/views/runs/_gold_timeline.slim
@@ -1,4 +1,4 @@
-- if run.completed?(timing)
+- if run.completed?(timing) && !run.is_a?(SumOfBestRun)
   .gold.timeline.timeline-animation style="width: #{run.duration(timing) / scale_to * 100.0}%"
     - run.collapsed_segments(timing).each_with_index do |segment, index|
       div style="width: #{segment.proportion(timing) * 100.0}%"


### PR DESCRIPTION
I wanted the ability to easily analyze my runs against my best splits. I'm not sure if this is something desired in the app itself or not, though. My feelings won't be hurt if the added complexity isn't desired.

Things of note:

- I disabled the sum of best run from showing anything in the charts. It didn't make sense to have that there since that data is already part of your normal charts.
- I hid the `gold_timeline` from the sum of best split timeline. It was just a big empty bar since every split is gold and the base run would never show anything there.
- I removed the `Swap Comparison` button because, at least as of right now, you can't view a `SumOfBestRun` as a `Run`, so you can't make that the base run for the `#show` action. I could add support for that, but it seems unnecessary.
- A  `SumOfBestRun` won't display a video, because it doesn't make sense.

<img width="321" alt="image" src="https://user-images.githubusercontent.com/293433/87192431-70332500-c2c4-11ea-9c3a-fee6ee221b5c.png">
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/293433/87192306-32ce9780-c2c4-11ea-98e0-faef4e62823a.png">
<img width="716" alt="image" src="https://user-images.githubusercontent.com/293433/87192337-45e16780-c2c4-11ea-8093-d03449609d8c.png">
