### PR TITLE
Address YouTube and Turbolinks issues

### DIFF
--- a/app/javascript/youtube.js
+++ b/app/javascript/youtube.js
@@ -1,11 +1,6 @@
 const async = require('async')
 
 window.onYouTubeIframeAPIReady = () => {
-  setupYouTubeVideos()
-  return true
-}
-
-function setupYouTubeVideos() {
   Array.from(document.querySelectorAll('[data-youtube]')).forEach(el => {
     if (el.dataset.loaded === '1') {
       return
@@ -19,8 +14,9 @@ function setupYouTubeVideos() {
       events: {
         'onReady': onYoutubePlayerReady
       }
-    });
+    })
   })
+  return true
 }
 
 onYoutubePlayerReady = (event) => {

--- a/app/javascript/youtube.js
+++ b/app/javascript/youtube.js
@@ -1,6 +1,7 @@
 const async = require('async')
 
 window.onYouTubeIframeAPIReady = () => {
+  setupYouTubeVideos()
   return true
 }
 
@@ -14,40 +15,68 @@ function setupYouTubeVideos() {
     const player = new YT.Player(el.id, {
       height: '100%',
       width: '100%',
-      videoId: el.dataset.video_id
-    });
-
-    const startOffset = parseInt(el.dataset.start_offset)
-    document.addEventListener('click', event => {
-      const segment = event.target.closest('.split');
-      if (segment === null) {
-        return
+      videoId: el.dataset.video_id,
+      events: {
+        'onReady': onYoutubePlayerReady
       }
-
-      player.seekTo(parseInt(segment.dataset.start_ms / 1000) + startOffset)
-      setTimeout(function() { player.playVideo() }, 10) // Running this instantly after seek causes the player to hang
     });
-
-    const ticker = document.getElementById(`video-progress-line-${el.dataset.run_id}`)
-    async.forever(next => {
-      try {
-        ticker.style.margin = `0 0 0 ${Math.max(player.getCurrentTime() - startOffset, 0) / (gon.scale_to / 1000) * 100}%`
-      } catch {}
-      setTimeout(() => next(), 100)
-    })
   })
 }
 
-// TODO: Is there a way we can deal with YouTube's async loading
-// and Turbolinks without polling?
-function waitForYouTubeAPI() {
-  if (window.YT !== undefined && typeof(window.YT.Player) === "function") {
-    setupYouTubeVideos()
-    return true
+onYoutubePlayerReady = (event) => {
+  const player = event.target
+  const el = player.getIframe()
+
+  const startOffset = parseInt(el.dataset.start_offset)
+  document.addEventListener('click', clickEvent => {
+    const segment = clickEvent.target.closest('.split');
+    if (segment === null) {
+      return
+    }
+
+    player.seekTo(parseInt(segment.dataset.start_ms / 1000) + startOffset)
+    setTimeout(function() { player.playVideo() }, 10) // Running this instantly after seek causes the player to hang
+  });
+
+  const ticker = document.getElementById(`video-progress-line-${el.dataset.run_id}`)
+  async.forever(next => {
+    try {
+      ticker.style.margin = `0 0 0 ${Math.max(player.getCurrentTime() - startOffset, 0) / (gon.scale_to / 1000) * 100}%`
+    } catch {}
+    setTimeout(() => next(), 100)
+  })
+}
+
+loadYouTubeJSIfNeeded = () => {
+  if (document.querySelectorAll('[data-youtube]').length === 0) {
+    return
   }
-  setTimeout(waitForYouTubeAPI, 100)
+
+  if (window.YT) {
+    // The YouTube API has been loaded once, but Turbolinks and YouTube don't get along, so let's let YouTube do its thing again
+    window.YT = undefined
+  }
+  let tag = document.createElement('script')
+  tag.setAttribute('id', 'youtube-async-script')
+
+  tag.src = "https://www.youtube.com/iframe_api"
+  let firstScriptTag = document.body.getElementsByTagName('script')[0]
+  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag)
+
+  if (window.YT !== undefined && typeof(window.YT.Player) === "function") {
+    onYouTubeIframeAPIReady()
+  }
+  document.addEventListener("turbolinks:before-cache", function() {
+    // Remove the YouTube scripts from the DOM so we don't get 87 copies of it over time
+    const ytElement = document.getElementById('www-widgetapi-script')
+    if (ytElement) {
+      ytElement.remove()
+    }
+    document.getElementById('youtube-async-script').remove();
+    document.removeEventListener("turbolinks:before-cache", arguments.callee)
+  })
 }
 
 document.addEventListener('turbolinks:load', function() {
-  waitForYouTubeAPI()
+  loadYouTubeJSIfNeeded()
 })

--- a/app/javascript/youtube.js
+++ b/app/javascript/youtube.js
@@ -19,7 +19,7 @@ window.onYouTubeIframeAPIReady = () => {
   return true
 }
 
-onYoutubePlayerReady = (event) => {
+const onYoutubePlayerReady = (event) => {
   const player = event.target
   const el = player.getIframe()
 
@@ -43,7 +43,7 @@ onYoutubePlayerReady = (event) => {
   })
 }
 
-loadYouTubeJSIfNeeded = () => {
+const loadYouTubeJSIfNeeded = () => {
   if (document.querySelectorAll('[data-youtube]').length === 0) {
     return
   }

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -13,7 +13,6 @@ html lang='en'
     = javascript_pack_tag('application', data: {turbolinks_track: 'reload'}, defer: true)
     = javascript_include_tag('https://checkout.stripe.com/checkout.js', defer: true)
     script src='https://player.twitch.tv/js/embed/v1.js' defer='defer'
-    script src='https://www.youtube.com/iframe_api' defer='defer'
     = stylesheet_link_tag :application, media: :all, data: {turbolinks_track: 'reload'}
     = stylesheet_pack_tag('bootstrap')
     = javascript_pack_tag('bootstrap', data: {turbolinks_track: 'reload'}, defer: false)


### PR DESCRIPTION
Closes #710 

This fixes the issue where we were having to poll to see if YouTube was ready due to Turbolinks issues. Additionally, it addresses #710 and fixes problems where a YouTube player wouldn't be seen as attached to the DOM when not performing a full page load.