### PR TITLE
Properly scale the video progress bar on the timelines for comparisons

### DIFF
--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -133,7 +133,7 @@ class RunsController < ApplicationController
                         {id: @run.user.id, name: @run.user.name}
                       end
 
-    gon.scale_to = [@run.duration(timing).to_ms, @compare_runs.map { |run| run.duration(timing).to_ms }].flatten.max
+    gon.scale_to = [@run.duration(timing).to_ms, *@compare_runs.map { |run| run.duration(timing).to_ms }].max
   rescue ActionController::UnknownFormat, ActiveRecord::RecordNotFound
     render :not_found, status: :not_found
   end

--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -133,7 +133,7 @@ class RunsController < ApplicationController
                         {id: @run.user.id, name: @run.user.name}
                       end
 
-    gon.scale_to = @run.duration_ms(timing)
+    gon.scale_to = [@run.duration(timing).to_ms, @compare_runs.map { |run| run.duration(timing).to_ms }].flatten.max
   rescue ActionController::UnknownFormat, ActiveRecord::RecordNotFound
     render :not_found, status: :not_found
   end


### PR DESCRIPTION
If you are comparing 2 runs and the base run is shorter than the other run, the base run video progress bar won't scale properly. When you click on a segment in the shorter (faster) run, the progress bar should go to the beginning of the segment. The actual video goes to the correct place, but the bar appears ahead of where it should due to scaling off of its duration and not the duration of the longer run.

![output](https://user-images.githubusercontent.com/293433/87717080-d6fd8600-c77d-11ea-855c-cd40122c3dab.gif)
