### PR TITLE
Fix duplication when filtering by nonempty categories

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,7 +15,7 @@ class Category < ApplicationRecord
 
   validates :name, presence: true
 
-  scope :nonempty, -> {joins(:runs)}
+  scope :nonempty, -> {joins(:game).group('categories.id').joins(:runs)}
 
   def self.global_aliases
     {

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,7 +15,7 @@ class Category < ApplicationRecord
 
   validates :name, presence: true
 
-  scope :nonempty, -> {joins(:game).group('categories.id').joins(:runs)}
+  scope :nonempty, -> {joins(:runs).distinct}
 
   def self.global_aliases
     {


### PR DESCRIPTION
In the current implementation, filtering by nonempty returns duplicate categories for each run associated with it. By joining the runs from the category's game, it will not return these duplicates, and each category should only appear once