### PR TITLE
Split off friendly race UUIDs into its own gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,15 +71,16 @@ gem 'cancancan'
 gem 'doorkeeper'
 
 # db
-gem 'active_median'
-gem 'active_record_union'
-gem 'activerecord-import'
-gem 'aws-sdk-rails'
-gem 'aws-sdk-s3'
-gem 'order_as_specified'
-gem 'pg'
-gem 'pg_search'
-gem 'strong_migrations'
+gem "active_median"
+gem "active_record_union"
+gem "activerecord-import"
+gem "aws-sdk-rails"
+gem "aws-sdk-s3"
+gem "friendly_uuid"
+gem "order_as_specified"
+gem "pg"
+gem "pg_search"
+gem "strong_migrations"
 
 # errors+logging
 gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
     ffi (1.13.0)
     font-awesome-sass (5.13.0)
       sassc (>= 1.11)
+    friendly_uuid (0.2.2)
     get_process_mem (0.2.5)
       ffi (~> 1.0)
     globalid (0.4.2)
@@ -506,6 +507,7 @@ DEPENDENCIES
   doorkeeper
   factory_bot_rails
   font-awesome-sass (~> 5.9)
+  friendly_uuid
   gon
   groupdate
   httparty

--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -1,9 +1,9 @@
 class RacesController < ApplicationController
-  before_action :set_races,        only: [:index]
-  before_action :set_race,         only: [:show, :update]
+  before_action :set_races, only: [:index]
+  before_action :set_race, only: [:show, :update]
   before_action :check_permission, only: [:show]
-  before_action :set_race_gon,     only: [:show]
-  before_action :shorten_url,      only: [:show]
+  before_action :set_race_gon, only: [:show]
+  before_action :shorten_url, only: [:show]
 
   def index
   end
@@ -33,7 +33,7 @@ class RacesController < ApplicationController
 
   def check_permission
     return unless @race.secret_visibility?
-    return if     @race.joinable?(token: race_params[:join_token], user: current_user)
+    return if @race.joinable?(token: race_params[:join_token], user: current_user)
 
     render :unauthorized, status: :unauthorized
   end
@@ -43,13 +43,13 @@ class RacesController < ApplicationController
 
     token = @race.entries.find_for(current_user).present? ? @race.join_token : nil
     gon.race = {
-      id:         @race.id,
-      join_token: token || race_params[:join_token]
+      id: @race.id,
+      join_token: token || race_params[:join_token],
     }
   end
 
   def set_race
-    @race = Race.friendly_find!(params[:id])
+    @race = Race.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     render "application/not_found"
   end


### PR DESCRIPTION
Recently I've been wanting to split some of our more general-purpose code into gems so others can benefit from the work, and this one was a pretty straightforward candidate.

This splits off the logic that shortens race UUIDs into reversible, stateless slugs for use in URLs. It's now a gem that can be used in any Rails application on any model that has UUID primary keys. It is located at [glacials/friendly_uuid](https://github.com/glacials/friendly_uuid).

Another split I might do later is our `Duration` implementation, as it's more precise than `ActiveSupport::Duration` and has been battle tested.

There are some formatting changes included here because I'm thinking of switching us over to [ruby-formatter/rufo](https://github.com/ruby-formatter/rufo) so I'm letting it leak some changes in as I test it out.