### PR TITLE
Use timesync instead of new Date() built in for count down/up

### DIFF
--- a/app/javascript/count.js
+++ b/app/javascript/count.js
@@ -2,6 +2,8 @@ import {setDriftlessInterval} from 'driftless'
 const moment = require('moment')
 require('moment-duration-format')(moment)
 
+import {ts} from 'time.js'
+
 // In this file, we attach to load instead of turbolinks:load because the functions re-find DOM elements every tick, so
 // we can re-use the same listener rather than attaching a new one every turbolinks:load. We choose to re-find DOM
 // elements every tick because ActionCable can replace our element with a new one rendered server-side at any moment.
@@ -11,7 +13,7 @@ require('moment-duration-format')(moment)
 window.addEventListener('load', () => {
   setDriftlessInterval(() => {
     Array.from(document.querySelectorAll('[data-abstime]')).forEach(el => {
-      const diffMS = moment().diff(moment(el.dataset.abstime))
+      const diffMS = moment(ts.now()).diff(moment(el.dataset.abstime))
       el.textContent = moment.duration(diffMS).format(el.dataset.abstimeFormat || 'HH:mm:ss.SS', {trim: false})
       if (diffMS < 0) {
         el.classList.add('bg-danger')


### PR DESCRIPTION
The default behavior of moment for object creation is to use new Date() to create the timestamp [[1]](https://momentjs.com/docs/#/parsing/now/), which pulls from the system clock.  If 2 computers are out of sync then the count down/up would be out of sync.  Switch over to calling `moment(ts.now)` which provides moment with a unix timestamp of the server's time, which is synced across all clients [[2]](https://momentjs.com/docs/#/parsing/unix-timestamp-milliseconds/).

I wasn't able to verify locally that this will fix the problem since I couldn't get the 2 devices to connect properly, but I'm fairly confident that this should fix the issue reported.