### PR TITLE
Add word wrap to race notes

### DIFF
--- a/app/javascript/vue/SpeedRunsLiveRaceList.vue
+++ b/app/javascript/vue/SpeedRunsLiveRaceList.vue
@@ -2,7 +2,7 @@
   <div class="card">
     <div class="card-header justify-content-between d-flex">
       <span>
-        <img src="http://cdn.speedrunslive.com/images/srl_305.png" style="height: 1em" alt="SpeedRunsLive logo" />
+        <img src="//cdn.speedrunslive.com/images/srl_305.png" style="height: 1em" alt="SpeedRunsLive logo" />
         <small
           class="fas fa-info-circle"
           content="For your convenience, these are the open races on SpeedRunsLive. Splits.io is not affiliated with SpeedRunsLive."

--- a/app/views/races/_title.slim
+++ b/app/views/races/_title.slim
@@ -65,7 +65,7 @@ race-title(
         div v-if="false" = render partial: 'shared/spinner'
         template v-if='!editing' = render partial: 'races/nav'
       .col-md-12.mt-2
-        pre.text-light v-show='!editing'
+        pre.text-light.text-wrap v-show='!editing'
           ' {{(race.notes || '').split('\n').splice(1).filter(s => s !== '').join('\n')}}
         template v-if='editing'
           textarea.text-dark.p-2 style='font-family: monospace; width: 100%' rows=10 v-model='notes' placeholder='First line: Race title supplement


### PR DESCRIPTION
Fixes #680 

Also load SRL logo schema-less so that it inherits from the initial page load,  fixes warning in console.