### PR TITLE
Allow trials without credit cards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
-source 'https://rubygems.org'
-ruby '2.7.1' # also update docker-compose.yml & docker-compose-production.yml
+source "https://rubygems.org"
+ruby "2.7.1" # also update docker-compose.yml & docker-compose-production.yml
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 group :test, :development do
-  gem 'pry-byebug'
-  gem 'pry-rails'
-  gem 'rspec-rails', '~> 4.0.0'
+  gem "pry-byebug"
+  gem "pry-rails"
+  gem "rspec-rails", "~> 4.0.0"
 end
 
 group :test do
@@ -29,7 +29,7 @@ group :development, :hot do
   gem 'rubocop-rails', require: false
 
   # profiling
-  gem 'derailed_benchmarks'
+  gem "derailed_benchmarks"
 
   # views
   gem 'rails_real_favicon'
@@ -83,47 +83,47 @@ gem "pg_search"
 gem "strong_migrations"
 
 # errors+logging
-gem 'newrelic_rpm'
-gem 'skylight', '~> 4.0.0'
+gem "newrelic_rpm"
+gem "skylight", "~> 4.0.0"
 
 # external communication
-gem 'httparty'
-gem 'rest-client'
-gem 'stripe-rails'
+gem "httparty"
+gem "rest-client"
+gem "stripe-rails"
 
 # parsing
-gem 'descriptive_statistics', require: 'descriptive_statistics/safe'
-gem 'moving_average'
+gem "descriptive_statistics", require: "descriptive_statistics/safe"
+gem "moving_average"
 
 # profiling
-gem 'memory_profiler'
-gem 'rack-mini-profiler'
+gem "memory_profiler"
+gem "rack-mini-profiler"
 
 # server/environment
-gem 'puma'
-gem 'rails', '~> 6.0'
+gem "puma"
+gem "rails", "~> 6.0"
 # see https://github.com/faye/websocket-driver-ruby/issues/58#issuecomment-394611125
-gem 'websocket-driver', github: 'faye/websocket-driver-ruby', ref: 'ee39af83d03ae3059c775583e4c4b291641257b8'
+gem "websocket-driver", github: "faye/websocket-driver-ruby", ref: "ee39af83d03ae3059c775583e4c4b291641257b8"
 
 # speediness
-gem 'bootsnap'
-gem 'dalli'
+gem "bootsnap"
+gem "dalli"
 
 # views
-gem 'bootstrap4-kaminari-views'
-gem 'font-awesome-sass', '~> 5.9'
-gem 'gon'
-gem 'image_processing'
-gem 'kaminari'
-gem 'purecss-rails', github: 'glacials/purecss-rails'
-gem 'sassc-rails'
-gem 'slim'
-gem 'webpacker', '>= 4.0.x'
+gem "bootstrap4-kaminari-views"
+gem "font-awesome-sass", "~> 5.9"
+gem "gon"
+gem "image_processing"
+gem "kaminari"
+gem "purecss-rails", github: "glacials/purecss-rails"
+gem "sassc-rails"
+gem "slim"
+gem "webpacker", ">= 4.0.x"
 
 # workers/jobs
-gem 'daemons'
-gem 'delayed_job_active_record'
-gem 'redis'
+gem "daemons"
+gem "delayed_job_active_record"
+gem "redis"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/app/controllers/subscription_trials_controller.rb
+++ b/app/controllers/subscription_trials_controller.rb
@@ -1,0 +1,9 @@
+class SubscriptionTrialsController < ApplicationController
+  def create
+    @subscription_trial = current_user.create_subscription_trial
+    redirect_back(
+      fallback_location: subscriptions_path,
+      notice: "Your free trial has started! It will end on #{@subscription_trial.ended_at}. Enjoy the new features :)",
+    )
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,18 +47,18 @@ module ApplicationHelper
       return link_to(user, user_path(user), class: ['badge', badge], content: title, 'v-tippy' => true)
     end
 
-    if user.patron?
-      badge = 'badge-secondary'
+    if user.patreon&.active?
+      badge = "badge-secondary"
       title = "#{user} is a Splits.io patron!"
     end
 
-    if user.patron?(tier: 2)
-      badge = 'badge-warning'
+    if user.patreon&.active?(tier: 2)
+      badge = "badge-warning"
       title = "#{user} is a Splits.io patron!"
     end
 
     if user.admin?
-      badge = 'badge-danger'
+      badge = "badge-danger"
       title = "#{user} is a Splits.io staff member!"
     end
 

--- a/app/models/patreon_user.rb
+++ b/app/models/patreon_user.rb
@@ -6,7 +6,7 @@ class PatreonUser < ApplicationRecord
   #    (grandfathered)
   # 2. Anyone paying at least the price of Gold via Patreon
   def has_predictions?
-    patron?(tier: 2, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+    active?(tier: 2, since_before: STRIPE_MIGRATION_DATE) || active?(tier: 4)
   end
 
   # Redirectors used to be a tier 3 Patreon feature, so they're available to:
@@ -14,7 +14,7 @@ class PatreonUser < ApplicationRecord
   #    (grandfathered)
   # 2. Anyone paying at least the price of Gold via Patreon
   def has_redirectors?
-    patron?(tier: 3, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+    active?(tier: 3, since_before: STRIPE_MIGRATION_DATE) || active?(tier: 4)
   end
 
   # Advanced comparisons used to be a tier 3 Patreon feature, so they're
@@ -22,35 +22,35 @@ class PatreonUser < ApplicationRecord
   # 1. Early patrons (grandfathered as a thank-you)
   # 2. Anyone paying at least the price of Gold via Patreon
   def has_advanced_comparisons?
-    patron?(tier: 3, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+    active?(tier: 3, since_before: STRIPE_MIGRATION_DATE) || active?(tier: 4)
   end
 
   # Sum-of-best leaderboards used to be free, so they're available to:
   # 1. Early patrons (grandfathered as a thank-you)
   # 2. Anyone paying at least the price of Gold via Patreon
   def has_sum_of_best_leaderboards?
-    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+    active?(tier: 1, since_before: STRIPE_MIGRATION_DATE) || active?(tier: 4)
   end
 
   # Hiding used to be free, so it's available to:
   # 1. Early patrons (grandfathered as a thank-you)
   # 2. Anyone paying at least the price of Gold via Patreon
   def has_hiding?
-    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+    active?(tier: 1, since_before: STRIPE_MIGRATION_DATE) || active?(tier: 4)
   end
 
   # Advanced video support used to be free, so it's available to:
   # 1. Early patrons (grandfathered as a thank-you)
   # 2. Anyone paying at least the price of Gold via Patreon
   def has_advanced_video?
-    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+    active?(tier: 1, since_before: STRIPE_MIGRATION_DATE) || active?(tier: 4)
   end
 
   # Auto-highlighting used to be free, so it's available to:
   # 1. Early patrons (grandfathered as a thank-you)
   # 2. Anyone paying at least the price of Gold via Patreon
   def has_autohighlight?
-    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+    active?(tier: 1, since_before: STRIPE_MIGRATION_DATE) || active?(tier: 4)
   end
 
   # Advanced analytics used to be lower-tier paid Patreon features, so they're
@@ -59,22 +59,22 @@ class PatreonUser < ApplicationRecord
   #    (grandfathered)
   # 2. Anyone paying at least the price of Gold via Patreon
   def has_advanced_analytics?
-    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+    active?(tier: 1, since_before: STRIPE_MIGRATION_DATE) || active?(tier: 4)
   end
 
   # Speedrun.com auto-submit is the first post-paywall-move paid feature, so is
   # only available to Gold users and those who are paying at least the
   # equivalent at Patreon.
   def has_srdc_submit?
-    patron?(tier: 4)
+    active?(tier: 4)
   end
 
-  # patron? returns something truthy if the user has been a patron at or above
-  # the given tier since the given `before` time. Not passing a `before` is the
-  # same as not caring how long the user has been a patron. Tier 4 is an
-  # imaginary tier equal to the price of Gold.
-  def patron?(tier: 0, before: Time.now.utc)
-    return false if patreon&.pledge_created_at.nil? || patreon.pledge_created_at > before
+  # active? returns something truthy if the user has been a patron at or above
+  # the given tier since the given `since_before` time. Not passing
+  # `since_before` is the same as not caring how long the user has been a
+  # patron. Tier 4 is an imaginary tier equal to the price of Gold.
+  def active?(tier: 0, since_before: Time.now.utc)
+    return false if pledge_created_at.nil? || pledge_created_at > since_before
 
     case tier
     when 0

--- a/app/models/patreon_user.rb
+++ b/app/models/patreon_user.rb
@@ -1,3 +1,92 @@
 class PatreonUser < ApplicationRecord
   belongs_to :user
+
+  # Predictions used to be a tier 2 Patreon feature, so they're available to:
+  # 1. Continued patrons who used to have them at the lower price point
+  #    (grandfathered)
+  # 2. Anyone paying at least the price of Gold via Patreon
+  def has_predictions?
+    patron?(tier: 2, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+  end
+
+  # Redirectors used to be a tier 3 Patreon feature, so they're available to:
+  # 1. Continued patrons who used to have them at the lower price point
+  #    (grandfathered)
+  # 2. Anyone paying at least the price of Gold via Patreon
+  def has_redirectors?
+    patron?(tier: 3, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+  end
+
+  # Advanced comparisons used to be a tier 3 Patreon feature, so they're
+  # available to:
+  # 1. Early patrons (grandfathered as a thank-you)
+  # 2. Anyone paying at least the price of Gold via Patreon
+  def has_advanced_comparisons?
+    patron?(tier: 3, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+  end
+
+  # Sum-of-best leaderboards used to be free, so they're available to:
+  # 1. Early patrons (grandfathered as a thank-you)
+  # 2. Anyone paying at least the price of Gold via Patreon
+  def has_sum_of_best_leaderboards?
+    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+  end
+
+  # Hiding used to be free, so it's available to:
+  # 1. Early patrons (grandfathered as a thank-you)
+  # 2. Anyone paying at least the price of Gold via Patreon
+  def has_hiding?
+    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+  end
+
+  # Advanced video support used to be free, so it's available to:
+  # 1. Early patrons (grandfathered as a thank-you)
+  # 2. Anyone paying at least the price of Gold via Patreon
+  def has_advanced_video?
+    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+  end
+
+  # Auto-highlighting used to be free, so it's available to:
+  # 1. Early patrons (grandfathered as a thank-you)
+  # 2. Anyone paying at least the price of Gold via Patreon
+  def has_autohighlight?
+    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+  end
+
+  # Advanced analytics used to be lower-tier paid Patreon features, so they're
+  # available to:
+  # 1. Continued patrons who used to have them at the lower price point
+  #    (grandfathered)
+  # 2. Anyone paying at least the price of Gold via Patreon
+  def has_advanced_analytics?
+    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4)
+  end
+
+  # Speedrun.com auto-submit is the first post-paywall-move paid feature, so is
+  # only available to Gold users and those who are paying at least the
+  # equivalent at Patreon.
+  def has_srdc_submit?
+    patron?(tier: 4)
+  end
+
+  # patron? returns something truthy if the user has been a patron at or above
+  # the given tier since the given `before` time. Not passing a `before` is the
+  # same as not caring how long the user has been a patron. Tier 4 is an
+  # imaginary tier equal to the price of Gold.
+  def patron?(tier: 0, before: Time.now.utc)
+    return false if patreon&.pledge_created_at.nil? || patreon.pledge_created_at > before
+
+    case tier
+    when 0
+      patreon.pledge_cents.positive?
+    when 1
+      patreon.pledge_cents >= 200
+    when 2
+      patreon.pledge_cents >= 400
+    when 3
+      patreon.pledge_cents >= 600
+    when 4
+      patreon.pledge_cents >= 900
+    end
+  end
 end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -10,9 +10,9 @@ class Race < ApplicationRecord
   belongs_to :game, optional: true
   belongs_to :category, optional: true
 
-  enum visibility: {public: 0, invite_only: 1, secret: 2}, _suffix: true
+  enum visibility: { public: 0, invite_only: 1, secret: 2 }, _suffix: true
 
-  belongs_to :owner, foreign_key: :user_id, class_name: 'User'
+  belongs_to :owner, foreign_key: :user_id, class_name: "User"
   has_many :entries, dependent: :destroy
   has_many :runners, through: :entries
   has_many :chat_messages, dependent: :destroy

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -3,9 +3,9 @@ class Subscription < ActiveRecord::Base
 
   scope :active,   -> { where(ended_at: nil) }
   scope :canceled, -> { where.not(canceled_at: nil) }
-  scope :is_tier1, -> { where(stripe_plan_id: ENV['STRIPE_PLAN_ID_TIER1']) }
-  scope :is_tier2, -> { where(stripe_plan_id: ENV['STRIPE_PLAN_ID_TIER2']) }
-  scope :is_tier3, -> { where(stripe_plan_id: ENV['STRIPE_PLAN_ID_TIER3']) }
+  scope :is_tier1, -> { where(stripe_plan_id: ENV['STRIPE_PLAN_ID_TIER1']) } # Deprecated
+  scope :is_tier2, -> { where(stripe_plan_id: ENV['STRIPE_PLAN_ID_TIER2']) } # Deprecated
+  scope :is_tier3, -> { where(stripe_plan_id: ENV['STRIPE_PLAN_ID_TIER3']) } # Only in-use tier
   scope :tier1,    -> { is_tier1.or(is_tier2).or(is_tier3) }
   scope :tier2,    -> { is_tier2.or(is_tier3) }
   scope :tier3,    -> { is_tier3 }
@@ -70,5 +70,41 @@ class Subscription < ActiveRecord::Base
 
     # Set canceled_at now; ended_at will be set by a Stripe webhook when the month runs out
     where(canceled_at: nil).update_all(canceled_at: Time.now.utc)
+  end
+
+  def self.has_predictions?
+    tier1.active.any?
+  end
+
+  def self.has_redirectors?
+    tier2.active.any?
+  end
+
+  def self.has_advanced_comparisons?
+    tier2.active.any?
+  end
+
+  def self.has_sum_of_best_leaderboards?
+    tier1.active.any?
+  end
+
+  def self.has_hiding?
+    tier1.active.any?
+  end
+
+  def self.has_advanced_video?
+    tier1.active.any?
+  end
+
+  def self.has_autohighlight?
+    tier1.active.any?
+  end
+
+  def self.has_advanced_analytics?
+    tier1.active.any?
+  end
+
+  def self.has_srdc_submit?
+    tier3.active.any?
   end
 end

--- a/app/models/subscription_trial.rb
+++ b/app/models/subscription_trial.rb
@@ -1,12 +1,12 @@
 class SubscriptionTrial < ApplicationRecord
-  SUBSCRIPTION_LENGTH = 14.days
+  TRIAL_DURATION = 14.days
 
   belongs_to :user
 
   validates :user_id, presence: true, uniqueness: true
 
   def ended_at
-    created_at + SUBSCRIPTION_LENGTH
+    created_at + TRIAL_DURATION
   end
 
   def expired?

--- a/app/models/subscription_trial.rb
+++ b/app/models/subscription_trial.rb
@@ -1,0 +1,51 @@
+class SubscriptionTrial < ApplicationRecord
+  SUBSCRIPTION_LENGTH = 14.days
+
+  belongs_to :user
+
+  validates :user_id, presence: true, uniqueness: true
+
+  def ended_at
+    created_at + SUBSCRIPTION_LENGTH
+  end
+
+  def expired?
+    Time.now.utc > ended_at
+  end
+
+  def has_predictions?
+    !expired?
+  end
+
+  def has_redirectors?
+    !expired?
+  end
+
+  def has_advanced_comparisons?
+    !expired?
+  end
+
+  def has_sum_of_best_leaderboards?
+    !expired?
+  end
+
+  def has_hiding?
+    !expired?
+  end
+
+  def has_advanced_video?
+    !expired?
+  end
+
+  def has_autohighlight?
+    !expired?
+  end
+
+  def has_advanced_analytics?
+    !expired?
+  end
+
+  def has_srdc_submit?
+    !expired?
+  end
+end

--- a/app/models/twitch_user.rb
+++ b/app/models/twitch_user.rb
@@ -1,12 +1,12 @@
-require 'twitch'
+require "twitch"
 
 class TwitchUser < ApplicationRecord
   belongs_to :user
 
-  has_many :twitch_user_follows,   foreign_key: :from_twitch_user_id, dependent: :destroy, inverse_of: 'from_twitch_user', class_name: 'TwitchUserFollow'
-  has_many :twitch_user_followers, foreign_key: :to_twitch_user_id,   dependent: :destroy, inverse_of: 'to_twitch_user',   class_name: 'TwitchUserFollow'
+  has_many :twitch_user_follows, foreign_key: :from_twitch_user_id, dependent: :destroy, inverse_of: "from_twitch_user", class_name: "TwitchUserFollow"
+  has_many :twitch_user_followers, foreign_key: :to_twitch_user_id, dependent: :destroy, inverse_of: "to_twitch_user", class_name: "TwitchUserFollow"
 
-  has_many :follows,   through: :twitch_user_follows,   source: :to_twitch_user
+  has_many :follows, through: :twitch_user_follows, source: :to_twitch_user
   has_many :followers, through: :twitch_user_followers, source: :from_twitch_user
 
   include AvatarSource
@@ -16,8 +16,8 @@ class TwitchUser < ApplicationRecord
     twitch_user.user = [
       current_user,
       twitch_user.user,
-      User.joins(:google).find_by(google_users: {email: auth.info.email}),
-      User.new(name: auth.info.name, email: auth.info.email)
+      User.joins(:google).find_by(google_users: { email: auth.info.email }),
+      User.new(name: auth.info.name, email: auth.info.email),
     ].compact.first
 
     unless twitch_user.user.save
@@ -30,18 +30,18 @@ class TwitchUser < ApplicationRecord
     twitch_user.assign_attributes(
       access_token: auth.credentials.token,
       refresh_token: auth.credentials.refresh_token,
-      name:          auth.info.nickname,
-      display_name:  auth.info.name,
-      email:         auth.info.email,
-      avatar:        auth.info.image || TwitchUser.default_avatar,
-      url:           auth.info.urls.Twitch
+      name: auth.info.nickname,
+      display_name: auth.info.name,
+      email: auth.info.email,
+      avatar: auth.info.image || TwitchUser.default_avatar,
+      url: auth.info.urls.Twitch,
     )
     twitch_user.save
     twitch_user
   end
 
   def self.default_avatar
-    'https://static-cdn.jtvnw.net/jtv_user_pictures/xarth/404_user_150x150.png'
+    "https://static-cdn.jtvnw.net/jtv_user_pictures/xarth/404_user_150x150.png"
   end
 
   def videos
@@ -51,13 +51,14 @@ class TwitchUser < ApplicationRecord
     refresh_tokens!
     retries += 1
     retry if retries < 2
+    raise e
   end
 
   # followed_twitch_ids returns a lazy enumerator over the user IDs of the
   # Twitch accounts (i.e. TwitchUser#twitch_id) this user follows.
   def followed_twitch_ids
     retries ||= 0
-    Twitch::Follows.from(twitch_id, token: access_token).map { |f| f['to_id'] }
+    Twitch::Follows.from(twitch_id, token: access_token).map { |f| f["to_id"] }
   rescue RestClient::Unauthorized => e
     refresh_tokens!
     retries += 1

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   has_many :runs, dependent: :nullify
   has_many :categories, -> { distinct }, through: :runs
-  has_many :games,      -> { distinct }, through: :runs
+  has_many :games, -> { distinct }, through: :runs
 
   has_many :run_likes, dependent: :destroy
 
@@ -24,6 +24,7 @@ class User < ApplicationRecord
   has_many :twitch_user_followers, foreign_key: :to_user_id,   dependent: :destroy, inverse_of: 'to_user',
                                    class_name: 'TwitchUserFollow'
 
+  has_one :trial, dependent: :destroy, class_name: "SubscriptionTrial"
   has_one :patreon, dependent: :destroy, class_name: "PatreonUser"
   has_one :twitch, dependent: :destroy, class_name: "TwitchUser"
   has_one :google, dependent: :destroy, class_name: "GoogleUser"
@@ -73,12 +74,6 @@ class User < ApplicationRecord
     search_for_name(term)
   end
 
-  # stay_insideathon is meant to help people deal with COVID-19, conditions where they might find themselves staying
-  # indoors a lot. If stay_insideathon returns true, all paid features become available to non-subscribers.
-  def self.stay_insideathon?
-    false
-  end
-
   def avatar
     [twitch, google].compact.map(&:avatar).first
   end
@@ -117,94 +112,56 @@ class User < ApplicationRecord
     name || "somebody"
   end
 
-  # Predictions used to be a tier 2 Patreon feature, so they're available to:
-  # 1. Gold users (the standard way of obtaining)
-  # 2. Continued patrons who used to have them at the lower price point (grandfathered)
-  # 3. Anyone paying at least the price of Gold via Patreon
+  # feature_grantors returns an array of objects that can give the user
+  # features, like a subscription, a grandfathered patreon subscription, or a
+  # trial. Every feature grantor must implement all `has_FEATURE?`-type methods
+  # below.
+  #
+  # If the feature grantor resolves to nil, it is assumed that it grants no
+  # features.
+  def feature_grantors
+    # TODO: Convert subscriptions from has-many to has-one
+    [patreon, subscriptions, trial].compact
+  end
+
   def has_predictions?
-    patron?(tier: 2, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4) || subscriptions.tier1.active.any? || admin? || self.class.stay_insideathon?
+    feature_grantors.any?(__method__)
   end
 
-  # Redirectors used to be a tier 3 Patreon feature, so they're available to:
-  # 1. Gold users (the standard way of obtaining)
-  # 2. Continued patrons who used to have them at the lower price point (grandfathered)
-  # 3. Anyone paying at least the price of Gold via Patreon
   def has_redirectors?
-    patron?(tier: 3, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4) || subscriptions.tier2.active.any? || admin? || self.class.stay_insideathon?
+    feature_grantors.any?(__method__)
   end
 
-  # Advanced comparisons used to be a tier 3 Patreon feature, so they're available to:
-  # 1. Gold users (the standard way of obtaining)
-  # 2. Early patrons (grandfathered as a thank-you)
-  # 3. Anyone paying at least the price of Gold via Patreon
   def has_advanced_comparisons?
-    patron?(tier: 3, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4) || subscriptions.tier2.active.any? || admin? || self.class.stay_insideathon?
+    feature_grantors.any?(__method__)
   end
 
-  # Sum-of-best leaderboards used to be free, so they're available to:
-  # 1. Gold users (the standard way of obtaining)
-  # 2. Early patrons (grandfathered as a thank-you)
-  # 3. Anyone paying at least the price of Gold via Patreon
   def has_sum_of_best_leaderboards?
-    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4) || subscriptions.tier1.active.any? || admin? || self.class.stay_insideathon?
+    feature_grantors.any?(__method__)
   end
 
-  # Hiding used to be free, so it's available to:
-  # 1. Gold users (the standard way of obtaining)
-  # 2. Early patrons (grandfathered as a thank-you)
-  # 3. Anyone paying at least the price of Gold via Patreon
   def has_hiding?
-    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4) || subscriptions.tier1.active.any? || admin? || self.class.stay_insideathon?
+    feature_grantors.any?(__method__)
   end
 
-  # Advanced video used to be free, so it's available to:
-  # 1. Gold users (the standard way of obtaining)
-  # 2. Early patrons (grandfathered as a thank-you)
-  # 3. Anyone paying at least the price of Gold via Patreon
   def has_advanced_video?
-    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4) || subscriptions.tier1.active.any? || admin? || self.class.stay_insideathon?
+    feature_grantors.any?(__method__)
   end
 
-  # Auto-highlight used to be free, so it's available to:
-  # 1. Gold users (the standard way of obtaining)
-  # 2. Early patrons (grandfathered as a thank-you)
-  # 3. Anyone paying at least the price of Gold via Patreon
   def has_autohighlight?
-    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4) || subscriptions.tier1.active.any? || admin? || self.class.stay_insideathon?
+    feature_grantors.any?(__method__)
   end
 
-  # Advanced analytics used to be lower-tier paid Patreon features, so they're available to:
-  # 1. Gold users (now the standard way of obtaining)
-  # 2. Continued patrons who used to have them at the lower price point (grandfathered)
-  # 3. Anyone paying at least the price of Gold via Patreon
   def has_advanced_analytics?
-    patron?(tier: 1, before: STRIPE_MIGRATION_DATE) || patron?(tier: 4) || subscriptions.tier1.active.any? || admin? || self.class.stay_insideathon?
+    feature_grantors.any?(__method__)
   end
 
-  # Speedrun.com auto-submit is the first post-paywall-move paid feature, so is only available to Gold users and
-  # those who are paying at least the equivalent at Patreon.
   def has_srdc_submit?
-    patron?(tier: 4) || subscriptions.tier3.active.any? || admin? || self.class.stay_insideathon?
+    feature_grantors.any?(__method__)
   end
 
-  # patron? returns something truthy if the user has been a patron at or above the given tier since the given `before`
-  # time. Not passing a `before` is the same as not caring how long the user has been a patron. Tier 4 is an imaginary
-  # tier equal to the price of Gold.
   def patron?(tier: 0, before: Time.now.utc)
-    return false if patreon&.pledge_created_at.nil? || patreon.pledge_created_at > before
-
-    case tier
-    when 0
-      patreon.pledge_cents.positive?
-    when 1
-      patreon.pledge_cents >= 200
-    when 2
-      patreon.pledge_cents >= 400
-    when 3
-      patreon.pledge_cents >= 600
-    when 4
-      patreon.pledge_cents >= 900
-    end
+    patreon&.patron?(tier: tier, before: before)
   end
 
   def admin?
@@ -212,7 +169,7 @@ class User < ApplicationRecord
       "29798286",  # Glacials
       "18946907",  # Batedurgonnadie
       "461527654", # tuna_can_ball
-    ].include?(twitch.try(:twitch_id))
+    ].include?(twitch&.twitch_id)
   end
 
   def likes?(run)
@@ -228,17 +185,17 @@ class User < ApplicationRecord
     case timing
     when Run::REAL
       Run.where(
-        id: runs.select('realtime_duration_ms, MAX(id) AS id')
+        id: runs.select("realtime_duration_ms, MAX(id) AS id")
           .group(:realtime_duration_ms)
           .where(category: run.category)
-          .map(&:id)
+          .map(&:id),
       ).order(realtime_duration_ms: :asc)
     when Run::GAME
       Run.where(
-        id: runs.select('gametime_duration_ms, MAX(id) AS id')
+        id: runs.select("gametime_duration_ms, MAX(id) AS id")
           .group(:gametime_duration_ms)
           .where(category: run.category)
-          .map(&:id)
+          .map(&:id),
       ).order(gametime_duration_ms: :asc)
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,10 +160,6 @@ class User < ApplicationRecord
     feature_grantors.any?(__method__)
   end
 
-  def patron?(tier: 0, before: Time.now.utc)
-    patreon&.patron?(tier: tier, before: before)
-  end
-
   def admin?
     [
       "29798286",  # Glacials

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -127,22 +127,16 @@ html lang='en'
               => icon('fas', 'flag-checkered')
               | Return to race
         header#header.m-1.p-0 = yield(:header)
+        - if current_user && current_user.email.nil?
+          .alert.alert-danger
+            ' You don't have an email attached to your Splits.io account. If
+            ' you become locked out your account will be irrecoverable. You
+            ' will also experience bugs around the site. Please add an email
+            ' address from the
+            a href=settings_path settings page
+            ' .
         .row.mx-2: #alerts.w-100 data-turbolinks-temporary=true
           = render partial: 'shared/alerts'
-        - if User.stay_insideathon? && !(current_user&.subscriptions&.active&.any?)
-          .row.mx-2.mb-3: .col-md-7.mx-auto: .card.border.border-primary
-            .card-body
-              h4.text-success
-                => icon('fas', 'home')
-                b> Stay-inside-a-thon!
-              ' To help you deal with COVID-19 all advanced analytics, comparisons, and other Gold features on Splits.io
-              ' are available for free until further notice. Stay home and grind attempts with the help of our best
-              ' tools, and avoid being a risk to yourself or others.
-              - if current_user.nil?
-                ' (Due to technical constraints, you must be signed in.)
-            .card-footer.clearfix: .float-right
-              a.btn.btn-outline-primary.mr-2 href='https://www.google.com/search?q=covid-19' COVID-19 info
-              a.btn.btn-outline-primary.mr-2 href=subscriptions_path What are Gold features?
         = yield
         - unless on_landing_page?
           footer#footer

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -128,11 +128,10 @@ html lang='en'
               | Return to race
         header#header.m-1.p-0 = yield(:header)
         - if current_user && current_user.email.nil?
-          .alert.alert-danger
+          .alert.alert-warning
             ' You don't have an email attached to your Splits.io account. If
-            ' you become locked out your account will be irrecoverable. You
-            ' will also experience bugs around the site. Please add an email
-            ' address from the
+            ' you become locked out your account will be irrecoverable.
+            ' Please add an email address from the
             a href=settings_path settings page
             ' .
         .row.mx-2: #alerts.w-100 data-turbolinks-temporary=true

--- a/app/views/settings/_patreon_benefits.slim
+++ b/app/views/settings/_patreon_benefits.slim
@@ -10,28 +10,28 @@
         small.text-muted = '/ mo'
     ul.list-unstyled.mt-3.mb-4
       h5 Your benefits
-      - if current_user.patron?(tier: 1, before: User::STRIPE_MIGRATION_DATE) || current_user.patron?(tier: 4)
+      - if current_user.patreon&.active?(tier: 1, before: User::STRIPE_MIGRATION_DATE) || current_user.patreon&.active?(tier: 4)
         li: b.text-success Tier 1:
         li Sum-of-best leaderboards
         li Hide runs without disowning them
         li Advanced analytics
         br
-      - if current_user.patron?(tier: 2, before: User::STRIPE_MIGRATION_DATE) || current_user.patron?(tier: 4)
+      - if current_user.patreon&.active?(tier: 2, before: User::STRIPE_MIGRATION_DATE) || current_user.patreon&.active?(tier: 4)
         li: b.text-success Tier 2:
         li Predict when you'll PB
         br
-      - if current_user.patron?(tier: 3, before: User::STRIPE_MIGRATION_DATE) || current_user.patron?(tier: 4)
+      - if current_user.patreon&.active?(tier: 3, before: User::STRIPE_MIGRATION_DATE) || current_user.patreon&.active?(tier: 4)
         li: b.text-success Tier 3:
         li Upgrade permalinks to redirectors
         li Compare splits with other runners
         br
-      - if current_user.patron?(tier: 4)
+      - if current_user.patreon&.active?(tier: 4)
         li: b.text-success Contributing more than the price of Splits.io Gold:
         li All other Splits.io Gold benefits!
-    - if current_user.patron?(before: User::STRIPE_MIGRATION_DATE)
+    - if current_user.patreon&.active?(before: User::STRIPE_MIGRATION_DATE)
       .alert.alert-info
         p: b You are a Splits.io founding user! You contributed to us when we were small. Thank you!
-        - unless current_user.patron?(tier: 4)
+        - unless current_user.patreon&.active?(tier: 4)
           p
             ' As thanks, you are grandfathered into your old price for as long as your keep your Patreon subscription
             ' active.

--- a/app/views/settings/index.slim
+++ b/app/views/settings/index.slim
@@ -15,7 +15,7 @@
     .col.p-1 = render partial: 'avatar'
     - if current_user.subscriptions.active.any?
       .col.p-1 = render partial: 'subscription'
-    - if current_user.patron?
+    - if current_user.patreon&.active?
       .col.p-1 = render partial: 'patreon_benefits'
   .p-1 = render partial: 'authorized_applications'
   .p-1 = render partial: 'my_applications'

--- a/app/views/subscriptions/index.slim
+++ b/app/views/subscriptions/index.slim
@@ -149,13 +149,25 @@
         - elsif current_user.nil?
           a.btn.btn-lg.btn-block.btn-primary href='#' data={toggle: :modal, target: '#signin'} Sign in to subscribe
         - else
-          / TODO: disable_with doesn't work in button_tag for some reason
-          = button_tag('Try free for 14 days', data: { \
-              disable_with: icon('fas', 'circle-notch', class: 'fa-spin').html_safe, \
-              plan_id: ENV['STRIPE_PLAN_ID_TIER3'] \
-            }, \
-            class: 'btn btn-lg btn-block btn-primary stripe-checkout', \
-          )
+          - if current_user.trial
+            / TODO: disable_with doesn't work in button_tag for some reason
+            = button_tag( \
+              current_user.trial.expired? ? 'Trial expired—click to upgrade' : 'Trial active—click to upgrade permanently', \
+              data: { \
+                disable_with: icon('fas', 'circle-notch', class: 'fa-spin').html_safe, \
+                plan_id: ENV['STRIPE_PLAN_ID_TIER3'] \
+              }, \
+              class: 'btn btn-lg btn-block btn-primary stripe-checkout', \
+            )
+          - else
+            / TODO: disable_with doesn't work in button_tag for some reason
+            small No credit card required
+            = button_tag('Try free for 14 days', data: { \
+                disable_with: icon('fas', 'circle-notch', class: 'fa-spin').html_safe, \
+                plan_id: ENV['STRIPE_PLAN_ID_TIER3'] \
+              }, \
+              class: 'btn btn-lg btn-block btn-primary stripe-checkout', \
+            )
   .card-deck.mb-3
     .card.text-center
       .card-header

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   pool: 5
   timout: 5000
   username: postgres
-  host: db
+  host: <%= ENV.fetch('DATABASE_HOST', 'db') %>
   port: 5432
 
 development: &development

--- a/config/initializers/s3.rb
+++ b/config/initializers/s3.rb
@@ -19,8 +19,8 @@ options = {
 if ENV['AWS_REGION'] == 'local'
   options.merge!(force_path_style: true)
 
-  options_internal = options.clone.merge!(endpoint: 'http://s3.localhost:4569')
-  options_external = options.clone.merge!(endpoint: 'http://localhost:4569')
+  options_internal = options.clone.merge!(endpoint: "http://#{ENV['S3_HOST']}:4569")
+  options_external = options.clone.merge!(endpoint: "http://localhost:4569")
 else
   options_internal = options
   options_external = options
@@ -32,4 +32,3 @@ $s3_client_external = Aws::S3::Client.new(options_external)
 
 $s3_bucket_internal = Aws::S3::Bucket.new(ENV['S3_BUCKET'], client: $s3_client_internal)
 $s3_bucket_external = Aws::S3::Bucket.new(ENV['S3_BUCKET'], client: $s3_client_external)
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:create, :show, :update]
   resources :password_reset_tokens, only: [:new, :create, :show]
+  resources :subscription_trials, only: [:create]
 
   get '/u/:user',     to: redirect('/users/%{user}'), as: :short_user
 

--- a/db/migrate/20201123024528_create_subscription_trials.rb
+++ b/db/migrate/20201123024528_create_subscription_trials.rb
@@ -1,0 +1,9 @@
+class CreateSubscriptionTrials < ActiveRecord::Migration[6.0]
+  def change
+    create_table :subscription_trials, id: :uuid do |t|
+      t.belongs_to :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_23_195259) do
+ActiveRecord::Schema.define(version: 2020_11_23_024528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -475,6 +475,13 @@ ActiveRecord::Schema.define(version: 2020_10_23_195259) do
     t.index ["run_id"], name: "index_splits_on_run_id"
   end
 
+  create_table "subscription_trials", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_subscription_trials_on_user_id"
+  end
+
   create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "stripe_session_id"
@@ -569,6 +576,7 @@ ActiveRecord::Schema.define(version: 2020_10_23_195259) do
   add_foreign_key "speedrun_dot_com_run_variables", "speedrun_dot_com_game_variable_values"
   add_foreign_key "speedrun_dot_com_users", "users"
   add_foreign_key "splits", "runs"
+  add_foreign_key "subscription_trials", "users"
   add_foreign_key "twitch_user_follows", "twitch_users", column: "from_twitch_user_id"
   add_foreign_key "twitch_user_follows", "twitch_users", column: "to_twitch_user_id"
   add_foreign_key "twitch_users", "users"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ x-server-environment:
   - REDIS_URL="redis/0"
   - RUST_BACKTRACE=1
   - S3_BUCKET=splits-io
+  - S3_HOST=s3.localhost
   - SITE_TITLE=Splits.io (Local)
   - SPLITSIO_CLIENT_SECRET
   - SPLITSIO_CLIENT_ID

--- a/lib/twitch.rb
+++ b/lib/twitch.rb
@@ -32,13 +32,13 @@ class Twitch
           response = Follows.get(id, token: token, cursor: cursor)
           raise StopIteration if response.code != 200
           body = JSON.parse(response.body)
-          raise StopIteration if body['data'].empty?
+          raise StopIteration if body["data"].empty?
 
-          cursor = body['pagination']['cursor']
+          cursor = body["pagination"]["cursor"]
           # Avoid getting caught in an infinite cursor loop
           raise StopIteration if seen_cursors.include?(cursor)
           seen_cursors.add(cursor)
-          body['data'].each do |follow|
+          body["data"].each do |follow|
             yielder << follow
           end
         end
@@ -73,7 +73,7 @@ class Twitch
           response = Videos.get(id, type, token: token, cursor: cursor)
           raise StopIteration if response.code != 200
           body = JSON.parse(response.body)
-          raise StopIteration if body['data'].empty?
+          raise StopIteration if body["data"].empty?
 
           cursor = body['pagination']['cursor']
           # Avoid getting caught in an infinite cursor loop


### PR DESCRIPTION
Currently trial subscriptions are handled completely by Stripe, and they don't have an option to allow them without entering payment information first.

This branch moves trial subscriptions to be handled by us, so that we don't need to have that requirement in place.

It also refactors the code that decides which users have which features, because it was getting pretty muddy having so many features with so many possible grantors of that feature. Now, each model that can grant a feature (Subscription, PatreonUser, and now SubscriptionTrial) has the same interface and can be easily queried en masse by User.

Also letting some more [`rufo`][1] lint leak through. I'm pretty confident I want us to switch to it.

Fixes #732.

[1]: https://github.com/ruby-formatter/rufo