### PR TITLE
Upgrade Skylight gem to 5.0beta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ gem "strong_migrations"
 
 # errors+logging
 gem "newrelic_rpm"
-gem "skylight", "~> 4.0.0"
+gem "skylight", "~> 5.0.0.beta4"
 
 # external communication
 gem "httparty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,10 +445,8 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    skylight (4.0.2)
-      skylight-core (= 4.0.2)
-    skylight-core (4.0.2)
-      activesupport (>= 4.2.0)
+    skylight (5.0.0.beta4)
+      activesupport (>= 5.2.0)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -557,7 +555,7 @@ DEPENDENCIES
   rufus-scheduler
   sassc-rails
   simplecov
-  skylight (~> 4.0.0)
+  skylight (~> 5.0.0.beta4)
   slim
   staccato
   stripe-rails


### PR DESCRIPTION
Thank you so much for participating in the [Skylight for Open Source](https://www.skylight.io/oss) program. We'd like to invite Splits I/O to participate in the public alpha for Source Locations for Skylight!

With this new feature, Skylight can help you pinpoint the locations in your code that correspond to events in the Skylight Event Sequence. This feature will allow your contributors to more easily find out exactly where an expensive operation originated without having to scour your code.

![https://d2ryfneqiwuan6.cloudfront.net/assets/skylight/docs/features/source-locations-popover-1181b5debba553a2b06bd914405997dce0334388b69fe3877c30acc21393ca25.png](https://d2ryfneqiwuan6.cloudfront.net/assets/skylight/docs/features/source-locations-popover-1181b5debba553a2b06bd914405997dce0334388b69fe3877c30acc21393ca25.png)

When you merge this PR, we will enable the feature flag for you on Skylight's servers. Then, once you deploy, you should begin seeing source locations data shortly after.

You can find documentation about the new feature at [https://www.skylight.io/support/source-locations](https://www.skylight.io/support/source-locations), and as always, if you have any questions or feedback, please get in touch with us either by responding here, emailing [support@skylight.io](mailto:support@skylight.io), or via the in-app communicator at the lower-right of your Skylight dashboard.