### PR TITLE
Update show.slim

### DIFF
--- a/app/views/races/show.slim
+++ b/app/views/races/show.slim
@@ -108,7 +108,7 @@ race inline-template=true race-id=@race.id v-cloak=true
               .card v-for='stream in value' :key='stream.id'
                 .card-body.p-0.twitch-stream
                   iframe(
-                    :src='`https://player.twitch.tv/?channel=${stream.id}&muted=true`'
+                    :src='`https://player.twitch.tv/?channel=${stream.id}&muted=true&parent=splits.io`'
                     height='100%'
                     width='100%'
                     frameborder='0'


### PR DESCRIPTION
On the races page, the embeded twitch streams say
![h58jteScGB](https://user-images.githubusercontent.com/35672537/103017078-155b5600-4511-11eb-9f45-a0d29a148b97.png)
Adding '&parent=splits.io' to the end of the embed link fixes the issue.
