### PR TITLE
Exclude timesync and SRL endpoints from tracking

### DIFF
--- a/app/controllers/api/v4/speedrunslive_races_controller.rb
+++ b/app/controllers/api/v4/speedrunslive_races_controller.rb
@@ -1,4 +1,6 @@
 class Api::V4::SpeedrunsliveRacesController < Api::V4::ApplicationController
+  skip_before_action :track
+
   def index
     Rails.cache.fetch('srl_races', expires_in: 1.minute) do
       render json: SpeedRunsLive::Race.all

--- a/app/controllers/api/v4/time_controller.rb
+++ b/app/controllers/api/v4/time_controller.rb
@@ -1,4 +1,6 @@
 class Api::V4::TimeController < Api::V4::ApplicationController
+  skip_before_action :track
+
   def create
     render status: :ok, json: {
       status: 200,


### PR DESCRIPTION
Each time these are called we're creating a job to track them, but these are called automatically during loading of other pages so that tracking information is not really all that useful.